### PR TITLE
Disable (un)marshalling of Futures

### DIFF
--- a/akka-http-json4s/src/test/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupportSpec.scala
+++ b/akka-http-json4s/src/test/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupportSpec.scala
@@ -54,6 +54,18 @@ class Json4sSupportSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       val entity = Await.result(Marshal(foo).to[RequestEntity], 100.millis)
       Await.result(Unmarshal(entity).to[Foo], 100.millis) shouldBe foo
     }
+
+    "disable marshalling for futures" in {
+      implicit val serialization = jackson.Serialization
+      assertDoesNotCompile("""Marshal(scala.concurrent.Future(())).to[RequestEntity]""")
+    }
+
+    "disable unmarshalling for futures" in {
+      implicit val serialization = jackson.Serialization
+      val entity: RequestEntity = null
+      assertDoesNotCompile("""Unmarshal(entity).to[scala.concurrent.Future[Unit]]""")
+    }
+
   }
 
   override protected def afterAll() = {


### PR DESCRIPTION
Before this change, using Json4sSupport would cause
`complete(Future[String](new RuntimeException))` to result in failure, but
`complete(Future[Unit](new RuntimeException))` would result in "{ }" being
rendered. This was very confusing.

This change prevents `complete(Future[Unit](new RuntimeException))`
from compiling, as expected (since `Unit`, and thus `Future[Unit]`, can't
be (un)marshalled).