### PR TITLE
Added stringifiation for JsError

### DIFF
--- a/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
+++ b/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
@@ -19,7 +19,7 @@ package de.heikoseeberger.akkahttpplayjson
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
-import play.api.libs.json.{ JsResultException, JsValue, Json, Reads, Writes }
+import play.api.libs.json.{ JsResultException, JsValue, JsError, Json, Reads, Writes }
 
 /**
  * Automatic to and from JSON marshalling/unmarshalling using an in-scope *play-json* protocol.
@@ -39,7 +39,7 @@ trait PlayJsonSupport {
    * @return unmarshaller for `A`
    */
   implicit def playJsonUnmarshaller[A](implicit reads: Reads[A]): FromEntityUnmarshaller[A] = {
-    def read(json: JsValue) = reads.reads(json).recoverTotal(error => throw JsResultException(error.errors))
+    def read(json: JsValue) = reads.reads(json).recoverTotal(error => throw new IllegalArgumentException(JsError.toJson(error).toString))
     Unmarshaller
       .byteStringUnmarshaller
       .forContentTypes(`application/json`)

--- a/akka-http-play-json/src/test/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupportSpec.scala
+++ b/akka-http-play-json/src/test/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupportSpec.scala
@@ -55,6 +55,12 @@ class PlayJsonSupportSpec extends WordSpec with Matchers with BeforeAndAfterAll 
       val iae = the[IllegalArgumentException] thrownBy Await.result(Unmarshal(entity).to[Foo], 100.millis)
       iae should have message "requirement failed: bar must be 'bar'!"
     }
+
+    "provide stringified error representation for parsing errors" in {
+      val entity = HttpEntity(MediaTypes.`application/json`, """{ "bar": 5 }""")
+      val iae = the[IllegalArgumentException] thrownBy Await.result(Unmarshal(entity).to[Foo], 100.millis)
+      iae should have message """{"obj.bar":[{"msg":["error.expected.jsstring"],"args":[]}]}"""
+    }
   }
 
   override protected def afterAll() = {


### PR DESCRIPTION
JsErrors from the play json parsing were being returned as JsResultExceptions,
which would then be sent as a string to the user, which is not a very
readable syntax error. This commit changes the behavior to use the syntax
shown on https://www.playframework.com/documentation/2.5.x/ScalaJson for
turning the JsError from parsing into a JSON string that can be used
as an error message.