### PR TITLE
Add akka-http-jackson with Jackson support for scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ akka-http-json provides JSON (un)marshalling support for [Akka](http://akka.io) 
 - [Json4s](https://github.com/json4s/json4s)
 - [Play JSON](https://www.playframework.com/documentation/2.5.x/ScalaJson)
 - [uPickle](https://github.com/lihaoyi/upickle-pprint)
+- [Jackson](https://github.com/FasterXML/jackson) via [Scala Module](https://github.com/FasterXML/jackson-module-scala) by default
 
 ## Installation
 
@@ -27,7 +28,7 @@ libraryDependencies ++= List(
 
 ## Usage
 
-Mix `ArgonautSupport`, `CirceSupport`, `Json4sSupport`, `PlayJsonSupport` or `UpickleSupport` or into your Akka HTTP code which is supposed to (un)marshal from/to JSON. Don't forget to provide the type class instances for the respective JSON libraries, if needed.
+Mix `ArgonautSupport`, `CirceSupport`, `Json4sSupport`, `PlayJsonSupport`, `UpickleSupport` or `JacksonSupport` or into your Akka HTTP code which is supposed to (un)marshal from/to JSON. Don't forget to provide the type class instances for the respective JSON libraries, if needed.
 
 ## Contribution policy ##
 

--- a/akka-http-jackson/build.sbt
+++ b/akka-http-jackson/build.sbt
@@ -1,0 +1,10 @@
+name := "akka-http-jackson"
+
+libraryDependencies ++= List(
+  Library.akkaHttp,
+  Library.akkaHttpJacksonJava,
+  Library.jacksonScala,
+  Library.scalaTest % "test"
+)
+
+initialCommands := """|import de.heikoseeberger.akkahttpjackson._""".stripMargin

--- a/akka-http-jackson/src/main/scala/de/heikoseeberger/akkahttpjackson/JacksonSupport.scala
+++ b/akka-http-jackson/src/main/scala/de/heikoseeberger/akkahttpjackson/JacksonSupport.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.akkahttpjackson
+
+import akka.http.javadsl.marshallers.jackson.Jackson
+import com.fasterxml.jackson.databind.ObjectMapper
+import akka.http.scaladsl.marshalling._
+import akka.http.scaladsl.model.MediaTypes.`application/json`
+import akka.http.scaladsl.unmarshalling.{ Unmarshaller, _ }
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+import scala.reflect._
+
+/**
+ * Automatic to and from JSON marshalling/unmarshalling usung an in-scope Jackon's ObjectMapper
+ */
+object JacksonSupport extends JacksonSupport {
+  val defaultObjectMapper = new ObjectMapper()
+    .registerModule(DefaultScalaModule)
+}
+
+/**
+ * JSON marshalling/unmarshalling using an in-scope Jackson's ObjectMapper
+ */
+trait JacksonSupport {
+  import JacksonSupport._
+
+  /**
+   * HTTP entity => `A`
+   *
+   * @param objectMapper
+   * @tparam A
+   * @return
+   */
+  implicit def jacksonUnmarshaller[A](
+    implicit
+    ct: ClassTag[A],
+    objectMapper: ObjectMapper = defaultObjectMapper
+  ): FromEntityUnmarshaller[A] = {
+    Unmarshaller
+      .byteStringUnmarshaller
+      .forContentTypes(`application/json`)
+      .mapWithCharset((data, charset) => {
+        val x: A = objectMapper.readValue(
+          data.decodeString(charset.nioCharset.name), ct.runtimeClass
+        ).asInstanceOf[A]
+        x
+      })
+  }
+
+  /**
+   * `A` => HTTP entity
+   *
+   * @param objectMapper
+   * @tparam Object
+   * @return
+   */
+  implicit def jacksonToEntityMarshaller[Object](
+    implicit
+    objectMapper: ObjectMapper = defaultObjectMapper
+  ): ToEntityMarshaller[Object] = {
+    Jackson.marshaller[Object](objectMapper)
+  }
+}

--- a/akka-http-jackson/src/test/scala/de/heikoseeberger/akkahttpjackson/ExampleApp.scala
+++ b/akka-http-jackson/src/test/scala/de/heikoseeberger/akkahttpjackson/ExampleApp.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.akkahttpjackson
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Directives
+import akka.stream.{ ActorMaterializer, Materializer }
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, ExecutionContext }
+import scala.io.StdIn
+
+object ExampleApp {
+
+  case class Response(payload: String)
+  case class Query(payload: String)
+
+  def main(args: Array[String]): Unit = {
+    implicit val system = ActorSystem()
+    implicit val mat = ActorMaterializer()
+    import system.dispatcher
+
+    // provide an implicit ObjectMapper if you want serialization/deserialization to use it
+    // instead of a default ObjectMapper configured only with DefaultScalaModule provided
+    // by JacksonSupport
+    //
+    // for example:
+    //
+    // implicit val objectMapper = new ObjectMapper()
+    //   .registerModule(DefaultScalaModule)
+    //   .registerModule(new GuavaModule())
+
+    Http().bindAndHandle(route, "127.0.0.1", 8080)
+
+    StdIn.readLine("Hit ENTER to exit")
+    Await.ready(system.terminate(), Duration.Inf)
+  }
+
+  def route(implicit ec: ExecutionContext, mat: Materializer) = {
+    import JacksonSupport._
+    import Directives._
+
+    (pathSingleSlash & post & entity(as[Query])) { query =>
+      complete(Response(payload = s"Response to '${query.payload}'"))
+    }
+  }
+}

--- a/akka-http-jackson/src/test/scala/de/heikoseeberger/akkahttpjackson/JacksonSupportSpec.scala
+++ b/akka-http-jackson/src/test/scala/de/heikoseeberger/akkahttpjackson/JacksonSupportSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.akkahttpjackson
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import com.fasterxml.jackson.databind.JsonMappingException
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+
+import scala.concurrent.Await
+import scala.concurrent.duration.{ Duration, DurationInt }
+
+object JacksonSupportSpec {
+  case class Foo(bar: String) { require(bar == "bar", "bar must be 'bar'!") }
+}
+
+class JacksonSupportSpec extends WordSpec with Matchers with BeforeAndAfterAll {
+
+  import JacksonSupport._
+  import JacksonSupportSpec._
+
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+
+  val foo = Foo("bar")
+
+  "JacksonSupport" should {
+    import system.dispatcher
+
+    "should enable marshalling and unmarshalling of case classes" in {
+      val entity = Await.result(Marshal(foo).to[RequestEntity], 100.millis)
+      Await.result(Unmarshal(entity).to[Foo], 100.millis) shouldBe foo
+    }
+
+    "provide proper error messages for requirement errors" in {
+      val entity = HttpEntity(MediaTypes.`application/json`, """{ "bar": "baz" }""")
+      val exception = the[JsonMappingException] thrownBy
+        Await.result(Unmarshal(entity).to[Foo], 100.millis)
+      exception.getMessage should include("bar must be 'bar'!")
+    }
+  }
+
+  override protected def afterAll() = {
+    Await.ready(system.terminate(), Duration.Inf)
+    super.afterAll()
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val akkaHttpJson = project
   .copy(id = "akka-http-json")
   .in(file("."))
-  .aggregate(akkaHttpPlayJson, akkaHttpJson4s, akkaHttpUpickle, akkaHttpCirce, akkaHttpArgonaut)
+  .aggregate(akkaHttpPlayJson, akkaHttpJson4s, akkaHttpUpickle, akkaHttpCirce, akkaHttpArgonaut, akkaHttpJackson)
   .enablePlugins(GitVersioning)
 
 lazy val akkaHttpArgonaut = project
@@ -27,6 +27,11 @@ lazy val akkaHttpUpickle = project
 lazy val akkaHttpPlayJson = project
   .copy(id = "akka-http-play-json")
   .in(file("akka-http-play-json"))
+  .enablePlugins(AutomateHeaderPlugin)
+
+lazy val akkaHttpJackson = project
+  .copy(id = "akka-http-jackson")
+  .in(file("akka-http-jackson"))
   .enablePlugins(AutomateHeaderPlugin)
 
 name := "akka-http-json"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,18 +9,22 @@ object Version {
   final val Scala     = "2.11.8"
   final val ScalaTest = "2.2.6"
   final val Upickle   = "0.4.1"
+  final val Jackson   = "2.7.5"
+  final val JacksonScalaModule = "2.7.2"
 }
 
 object Library {
-  val akkaHttp      = "com.typesafe.akka" %% "akka-http-experimental" % Version.Akka
-  val argonaut      = "io.argonaut"       %% "argonaut"               % Version.Argonaut
-  val circe         = "io.circe"          %% "circe-core"             % Version.Circe
-  val circeJawn     = "io.circe"          %% "circe-jawn"             % Version.Circe
-  val circeGeneric  = "io.circe"          %% "circe-generic"          % Version.Circe
-  val json4sCore    = "org.json4s"        %% "json4s-core"            % Version.Json4s
-  val json4sJackson = "org.json4s"        %% "json4s-jackson"         % Version.Json4s
-  val json4sNative  = "org.json4s"        %% "json4s-native"          % Version.Json4s
-  val playJson      = "com.typesafe.play" %% "play-json"              % Version.Play
-  val scalaTest     = "org.scalatest"     %% "scalatest"              % Version.ScalaTest
-  val upickle       = "com.lihaoyi"       %% "upickle"                % Version.Upickle
+  val akkaHttp            = "com.typesafe.akka"            %% "akka-http-experimental"         % Version.Akka
+  val argonaut            = "io.argonaut"                  %% "argonaut"                       % Version.Argonaut
+  val circe               = "io.circe"                     %% "circe-core"                     % Version.Circe
+  val circeJawn           = "io.circe"                     %% "circe-jawn"                     % Version.Circe
+  val circeGeneric        = "io.circe"                     %% "circe-generic"                  % Version.Circe
+  val json4sCore          = "org.json4s"                   %% "json4s-core"                    % Version.Json4s
+  val json4sJackson       = "org.json4s"                   %% "json4s-jackson"                 % Version.Json4s
+  val json4sNative        = "org.json4s"                   %% "json4s-native"                  % Version.Json4s
+  val playJson            = "com.typesafe.play"            %% "play-json"                      % Version.Play
+  val scalaTest           = "org.scalatest"                %% "scalatest"                      % Version.ScalaTest
+  val upickle             = "com.lihaoyi"                  %% "upickle"                        % Version.Upickle
+  val jacksonScala        = "com.fasterxml.jackson.module" %% "jackson-module-scala"           % Version.JacksonScalaModule
+  val akkaHttpJacksonJava = "com.typesafe.akka"            %% "akka-http-jackson-experimental" % Version.Akka
 }


### PR DESCRIPTION
akka-http-jackson module adds support for using Jackson with akka-http from Scala.

Jackson provides very fast serialization/deserialization, completely transparent generation of codecs for Scala case classes and very easy to customize using standard Jackson annotations.

Comes with an example app and some tests.

I think it would be a good addition to akka-http-json.