### PR TITLE
Unmarshallers fail with NoContentException on empty entity (#88)

### DIFF
--- a/akka-http-argonaut/src/main/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupport.scala
+++ b/akka-http-argonaut/src/main/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupport.scala
@@ -22,7 +22,9 @@ import akka.http.scaladsl.unmarshalling.{
   FromEntityUnmarshaller,
   Unmarshaller
 }
+import akka.util.ByteString
 import argonaut.{ DecodeJson, EncodeJson, Json, Parse, PrettyParams }
+
 import scalaz.Scalaz._
 
 /**
@@ -39,8 +41,19 @@ object ArgonautSupport extends ArgonautSupport
   */
 trait ArgonautSupport {
 
+  private val jsonStringUnmarshaller: FromEntityUnmarshaller[String] =
+    Unmarshaller.byteStringUnmarshaller
+      .forContentTypes(`application/json`)
+      .mapWithCharset {
+        case (ByteString.empty, _) ⇒ throw Unmarshaller.NoContentException
+        case (data, charset)       ⇒ data.decodeString(charset.nioCharset.name)
+      }
+
+  private val jsonStringMarshaller: ToEntityMarshaller[String] =
+    Marshaller.stringMarshaller(`application/json`)
+
   /**
-    * HTTP entity => `A`
+    * HTTP entity ⇒ `A`
     *
     * @param decoder decoder for `A`
     * @tparam A type to decode
@@ -49,26 +62,21 @@ trait ArgonautSupport {
   implicit def argonautUnmarshaller[A](
       implicit decoder: DecodeJson[A]
   ): FromEntityUnmarshaller[A] =
-    Unmarshaller.byteStringUnmarshaller
-      .forContentTypes(`application/json`)
-      .mapWithCharset { (data, charset) =>
-        Parse
-          .parse(data.decodeString(charset.nioCharset.name))
-          .toEither match {
-          case Right(json)   => json
-          case Left(message) => sys.error(message)
-        }
+    jsonStringUnmarshaller.map { data ⇒
+      Parse.parse(data).toEither match {
+        case Right(json)   ⇒ json
+        case Left(message) ⇒ sys.error(message)
       }
-      .map { json =>
-        decoder.decodeJson(json).result.toEither match {
-          case Right(entity) => entity
-          case Left((message, history)) =>
-            sys.error(message + " - " + history.shows)
-        }
+    }.map { json ⇒
+      decoder.decodeJson(json).result.toEither match {
+        case Right(entity) ⇒ entity
+        case Left((message, history)) ⇒
+          sys.error(message + " - " + history.shows)
       }
+    }
 
   /**
-    * `A` => HTTP entity
+    * `A` ⇒ HTTP entity
     *
     * @param encoder encoder for `A`
     * @param printer pretty printer function
@@ -77,9 +85,8 @@ trait ArgonautSupport {
     */
   implicit def argonautToEntityMarshaller[A](
       implicit encoder: EncodeJson[A],
-      printer: Json => String = PrettyParams.nospace.pretty
+      printer: Json ⇒ String = PrettyParams.nospace.pretty
   ): ToEntityMarshaller[A] =
-    Marshaller.StringMarshaller
-      .wrap(`application/json`)(printer)
-      .compose(encoder.apply)
+    jsonStringMarshaller.compose(printer).compose(encoder.apply)
+
 }

--- a/akka-http-argonaut/src/test/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupportSpec.scala
+++ b/akka-http-argonaut/src/test/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupportSpec.scala
@@ -18,13 +18,12 @@ package de.heikoseeberger.akkahttpargonaut
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.ContentTypes.`application/json`
 import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
-
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 

--- a/akka-http-argonaut/src/test/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupportSpec.scala
+++ b/akka-http-argonaut/src/test/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupportSpec.scala
@@ -18,10 +18,13 @@ package de.heikoseeberger.akkahttpargonaut
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
-import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
+
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
@@ -65,6 +68,28 @@ class ArgonautSupportSpec
         .to[Foo]
         .failed
         .map(_ should have message "requirement failed: bar must be 'bar'!")
+    }
+
+    "fail with NoContentException when unmarshalling empty entities" in {
+      import argonaut.Argonaut._
+      implicit def FooCodec = casecodec1(Foo.apply, Foo.unapply)("bar")
+
+      val entity = HttpEntity.empty(`application/json`)
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe Unmarshaller.NoContentException)
+    }
+
+    "fail with UnsupportedContentTypeException when Content-Type is not `application/json`" in {
+      import argonaut.Argonaut._
+      implicit def FooCodec = casecodec1(Foo.apply, Foo.unapply)("bar")
+
+      val entity = HttpEntity("""{ "bar": "bar" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe UnsupportedContentTypeException(`application/json`))
     }
   }
 

--- a/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
+++ b/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
@@ -39,19 +39,19 @@ object CirceSupport extends CirceSupport
   */
 trait CirceSupport {
 
-  private val jsonStringUnmarshaller: FromEntityUnmarshaller[String] =
+  private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
       .forContentTypes(`application/json`)
       .mapWithCharset {
-        case (ByteString.empty, _) ⇒ throw Unmarshaller.NoContentException
-        case (data, charset)       ⇒ data.decodeString(charset.nioCharset.name)
+        case (ByteString.empty, _) => throw Unmarshaller.NoContentException
+        case (data, charset)       => data.decodeString(charset.nioCharset.name)
       }
 
-  private val jsonStringMarshaller: ToEntityMarshaller[String] =
+  private val jsonStringMarshaller =
     Marshaller.stringMarshaller(`application/json`)
 
   /**
-    * HTTP entity ⇒ `A`
+    * HTTP entity => `A`
     *
     * @param decoder decoder for `A`, probably created by `circe.generic`
     * @tparam A type to decode
@@ -60,10 +60,10 @@ trait CirceSupport {
   implicit def circeUnmarshaller[A](
       implicit decoder: Decoder[A]
   ): FromEntityUnmarshaller[A] =
-    jsonStringUnmarshaller.map(data ⇒ jawn.decode(data).valueOr(throw _))
+    jsonStringUnmarshaller.map(data => jawn.decode(data).valueOr(throw _))
 
   /**
-    * `A` ⇒ HTTP entity
+    * `A` => HTTP entity
     *
     * @param encoder encoder for `A`, probably created by `circe.generic`
     * @param printer pretty printer function
@@ -72,7 +72,7 @@ trait CirceSupport {
     */
   implicit def circeToEntityMarshaller[A](
       implicit encoder: Encoder[A],
-      printer: Json ⇒ String = Printer.noSpaces.pretty
+      printer: Json => String = Printer.noSpaces.pretty
   ): ToEntityMarshaller[A] =
     jsonStringMarshaller.compose(printer).compose(encoder.apply)
 }

--- a/akka-http-circe/src/test/scala/de/heikoseeberger/akkahttpcirce/CirceSupportSpec.scala
+++ b/akka-http-circe/src/test/scala/de/heikoseeberger/akkahttpcirce/CirceSupportSpec.scala
@@ -18,10 +18,13 @@ package de.heikoseeberger.akkahttpcirce
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.ContentTypes.`application/json`
 import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
-import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
+
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
@@ -61,6 +64,24 @@ class CirceSupportSpec
         .to[Foo]
         .failed
         .map(_ should have message "requirement failed: bar must be 'bar'!")
+    }
+
+    "fail with NoContentException when unmarshalling empty entities" in {
+      import io.circe.generic.auto._
+      val entity = HttpEntity.empty(`application/json`)
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe Unmarshaller.NoContentException)
+    }
+
+    "fail with UnsupportedContentTypeException when Content-Type is not `application/json`" in {
+      import io.circe.generic.auto._
+      val entity = HttpEntity("""{ "bar": "bar" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe UnsupportedContentTypeException(`application/json`))
     }
 
   }

--- a/akka-http-circe/src/test/scala/de/heikoseeberger/akkahttpcirce/CirceSupportSpec.scala
+++ b/akka-http-circe/src/test/scala/de/heikoseeberger/akkahttpcirce/CirceSupportSpec.scala
@@ -24,7 +24,6 @@ import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeExcep
 import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
-
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 

--- a/akka-http-jackson/src/test/scala/de/heikoseeberger/akkahttpjackson/JacksonSupportSpec.scala
+++ b/akka-http-jackson/src/test/scala/de/heikoseeberger/akkahttpjackson/JacksonSupportSpec.scala
@@ -18,10 +18,13 @@ package de.heikoseeberger.akkahttpjackson
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
-import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
+
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
@@ -61,6 +64,22 @@ class JacksonSupportSpec
         .map(
           _.getMessage should include("requirement failed: bar must be 'bar'!")
         )
+    }
+
+    "fail with NoContentException when unmarshalling empty entities" in {
+      val entity = HttpEntity.empty(`application/json`)
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe Unmarshaller.NoContentException)
+    }
+
+    "fail with UnsupportedContentTypeException when Content-Type is not `application/json`" in {
+      val entity = HttpEntity("""{ "bar": "bar" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe UnsupportedContentTypeException(`application/json`))
     }
   }
 

--- a/akka-http-jackson/src/test/scala/de/heikoseeberger/akkahttpjackson/JacksonSupportSpec.scala
+++ b/akka-http-jackson/src/test/scala/de/heikoseeberger/akkahttpjackson/JacksonSupportSpec.scala
@@ -18,13 +18,12 @@ package de.heikoseeberger.akkahttpjackson
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.ContentTypes.`application/json`
 import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
-
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 

--- a/akka-http-json4s/src/main/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupport.scala
+++ b/akka-http-json4s/src/main/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupport.scala
@@ -17,7 +17,6 @@
 package de.heikoseeberger.akkahttpjson4s
 
 import java.lang.reflect.InvocationTargetException
-
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{
@@ -50,19 +49,19 @@ object Json4sSupport extends Json4sSupport {
 trait Json4sSupport {
   import Json4sSupport._
 
-  private val jsonStringUnmarshaller: FromEntityUnmarshaller[String] =
+  private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
       .forContentTypes(`application/json`)
       .mapWithCharset {
-        case (ByteString.empty, _) ⇒ throw Unmarshaller.NoContentException
-        case (data, charset)       ⇒ data.decodeString(charset.nioCharset.name)
+        case (ByteString.empty, _) => throw Unmarshaller.NoContentException
+        case (data, charset)       => data.decodeString(charset.nioCharset.name)
       }
 
-  private val jsonStringMarshaller: ToEntityMarshaller[String] =
+  private val jsonStringMarshaller =
     Marshaller.stringMarshaller(`application/json`)
 
   /**
-    * HTTP entity ⇒ `A`
+    * HTTP entity => `A`
     *
     * @tparam A type to decode
     * @return unmarshaller for `A`
@@ -71,19 +70,19 @@ trait Json4sSupport {
       implicit serialization: Serialization,
       formats: Formats
   ): FromEntityUnmarshaller[A] =
-    jsonStringUnmarshaller.map { data ⇒
+    jsonStringUnmarshaller.map { data =>
       serialization.read(data)
     }.recover(
-      _ ⇒
-        _ ⇒ {
+      _ =>
+        _ => {
           case MappingException("unknown error",
-                                ite: InvocationTargetException) ⇒
+                                ite: InvocationTargetException) =>
             throw ite.getCause
       }
     )
 
   /**
-    * `A` ⇒ HTTP entity
+    * `A` => HTTP entity
     *
     * @tparam A type to encode, must be upper bounded by `AnyRef`
     * @return marshaller for any `A` value
@@ -94,9 +93,9 @@ trait Json4sSupport {
       shouldWritePretty: ShouldWritePretty = ShouldWritePretty.False
   ): ToEntityMarshaller[A] =
     shouldWritePretty match {
-      case ShouldWritePretty.False ⇒
+      case ShouldWritePretty.False =>
         jsonStringMarshaller.compose(serialization.write[A])
-      case ShouldWritePretty.True ⇒
+      case ShouldWritePretty.True =>
         jsonStringMarshaller.compose(serialization.writePretty[A])
     }
 }

--- a/akka-http-json4s/src/test/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupportSpec.scala
+++ b/akka-http-json4s/src/test/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupportSpec.scala
@@ -25,7 +25,6 @@ import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.json4s.{ DefaultFormats, jackson, native }
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
-
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 

--- a/akka-http-json4s/src/test/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupportSpec.scala
+++ b/akka-http-json4s/src/test/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupportSpec.scala
@@ -18,11 +18,14 @@ package de.heikoseeberger.akkahttpjson4s
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.ContentTypes.`application/json`
 import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
-import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.json4s.{ DefaultFormats, jackson, native }
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
+
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
@@ -56,7 +59,7 @@ class Json4sSupportSpec
         .map(_ shouldBe foo)
     }
 
-    "enable marshalling and unmarshalling objects for default `DefaultFormats` and `native.Serialization`" in {
+    "enable marshalling and unmarshalling objects for `DefaultFormats` and `native.Serialization`" in {
       implicit val serialization = native.Serialization
       Marshal(foo)
         .to[RequestEntity]
@@ -72,6 +75,24 @@ class Json4sSupportSpec
         .to[Foo]
         .failed
         .map(_ should have message "requirement failed: bar must be 'bar'!")
+    }
+
+    "fail with NoContentException when unmarshalling empty entities" in {
+      implicit val serialization = native.Serialization
+      val entity                 = HttpEntity.empty(`application/json`)
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe Unmarshaller.NoContentException)
+    }
+
+    "fail with UnsupportedContentTypeException when Content-Type is not `application/json`" in {
+      implicit val serialization = native.Serialization
+      val entity                 = HttpEntity("""{ "bar": "bar" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe UnsupportedContentTypeException(`application/json`))
     }
   }
 

--- a/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
+++ b/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
@@ -35,19 +35,19 @@ object PlayJsonSupport extends PlayJsonSupport
   */
 trait PlayJsonSupport {
 
-  private val jsonStringUnmarshaller: FromEntityUnmarshaller[String] =
+  private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
       .forContentTypes(`application/json`)
       .mapWithCharset {
-        case (ByteString.empty, _) ⇒ throw Unmarshaller.NoContentException
-        case (data, charset)       ⇒ data.decodeString(charset.nioCharset.name)
+        case (ByteString.empty, _) => throw Unmarshaller.NoContentException
+        case (data, charset)       => data.decodeString(charset.nioCharset.name)
       }
 
-  private val jsonStringMarshaller: ToEntityMarshaller[String] =
+  private val jsonStringMarshaller =
     Marshaller.stringMarshaller(`application/json`)
 
   /**
-    * HTTP entity ⇒ `A`
+    * HTTP entity => `A`
     *
     * @param reads reader for `A`
     * @tparam A type to decode
@@ -60,14 +60,14 @@ trait PlayJsonSupport {
       reads
         .reads(json)
         .recoverTotal(
-          error ⇒
+          error =>
             throw new IllegalArgumentException(JsError.toJson(error).toString)
         )
-    jsonStringUnmarshaller.map(data ⇒ read(Json.parse(data)))
+    jsonStringUnmarshaller.map(data => read(Json.parse(data)))
   }
 
   /**
-    * `A` ⇒ HTTP entity
+    * `A` => HTTP entity
     *
     * @param writes writer for `A`
     * @param printer pretty printer function
@@ -76,7 +76,7 @@ trait PlayJsonSupport {
     */
   implicit def playJsonMarshaller[A](
       implicit writes: Writes[A],
-      printer: JsValue ⇒ String = Json.prettyPrint
+      printer: JsValue => String = Json.prettyPrint
   ): ToEntityMarshaller[A] =
     jsonStringMarshaller.compose(printer).compose(writes.writes)
 }

--- a/akka-http-play-json/src/test/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupportSpec.scala
+++ b/akka-http-play-json/src/test/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupportSpec.scala
@@ -18,14 +18,13 @@ package de.heikoseeberger.akkahttpplayjson
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.ContentTypes.`application/json`
 import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
 import play.api.libs.json.Json
-
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 

--- a/akka-http-play-json/src/test/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupportSpec.scala
+++ b/akka-http-play-json/src/test/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupportSpec.scala
@@ -18,11 +18,14 @@ package de.heikoseeberger.akkahttpplayjson
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
-import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
 import play.api.libs.json.Json
+
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
@@ -74,6 +77,22 @@ class PlayJsonSupportSpec
         .map(
           _ should have message """{"obj.bar":[{"msg":["error.expected.jsstring"],"args":[]}]}"""
         )
+    }
+
+    "fail with NoContentException when unmarshalling empty entities" in {
+      val entity = HttpEntity.empty(`application/json`)
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe Unmarshaller.NoContentException)
+    }
+
+    "fail with UnsupportedContentTypeException when Content-Type is not `application/json`" in {
+      val entity = HttpEntity("""{ "bar": "bar" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe UnsupportedContentTypeException(`application/json`))
     }
   }
 

--- a/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleSupport.scala
+++ b/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleSupport.scala
@@ -36,19 +36,19 @@ object UpickleSupport extends UpickleSupport
   */
 trait UpickleSupport {
 
-  private val jsonStringUnmarshaller: FromEntityUnmarshaller[String] =
+  private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
       .forContentTypes(`application/json`)
       .mapWithCharset {
-        case (ByteString.empty, _) ⇒ throw Unmarshaller.NoContentException
-        case (data, charset)       ⇒ data.decodeString(charset.nioCharset.name)
+        case (ByteString.empty, _) => throw Unmarshaller.NoContentException
+        case (data, charset)       => data.decodeString(charset.nioCharset.name)
       }
 
-  private val jsonStringMarshaller: ToEntityMarshaller[String] =
+  private val jsonStringMarshaller =
     Marshaller.stringMarshaller(`application/json`)
 
   /**
-    * HTTP entity ⇒ `A`
+    * HTTP entity => `A`
     *
     * @param reader reader for `A`
     * @tparam A type to decode
@@ -57,10 +57,10 @@ trait UpickleSupport {
   implicit def upickleUnmarshaller[A](
       implicit reader: Reader[A]
   ): FromEntityUnmarshaller[A] =
-    jsonStringUnmarshaller.map(data ⇒ readJs[A](json.read(data)))
+    jsonStringUnmarshaller.map(data => readJs[A](json.read(data)))
 
   /**
-    * `A` ⇒ HTTP entity
+    * `A` => HTTP entity
     *
     * @param writer writer for `A`
     * @param printer pretty printer function
@@ -69,7 +69,7 @@ trait UpickleSupport {
     */
   implicit def upickleMarshaller[A](
       implicit writer: Writer[A],
-      printer: Js.Value ⇒ String = json.write(_, 0)
+      printer: Js.Value => String = json.write(_, 0)
   ): ToEntityMarshaller[A] =
     jsonStringMarshaller.compose(printer).compose(writeJs[A])
 }

--- a/akka-http-upickle/src/test/scala/de/heikoseeberger/akkahttpupickle/UpickleSupportSpec.scala
+++ b/akka-http-upickle/src/test/scala/de/heikoseeberger/akkahttpupickle/UpickleSupportSpec.scala
@@ -18,13 +18,12 @@ package de.heikoseeberger.akkahttpupickle
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model.ContentTypes.`application/json`
 import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
-
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 


### PR DESCRIPTION
Fixes #88 

Other changes:
* added one more test to ensure the `application/json` media-type is requested by the unmarshaller.
* Factorized the `jsonStringUnmarshaller` and `jsonStringMarshaller`. This is thread safe and should be more efficient.
