### PR TITLE
PlayJson: Use a RejectionError to transport a parsing error

### DIFF
--- a/akka-http-play-json/src/test/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupportSpec.scala
+++ b/akka-http-play-json/src/test/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupportSpec.scala
@@ -20,11 +20,13 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.ContentTypes.`application/json`
 import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
+import akka.http.scaladsl.server.{ RejectionError, ValidationRejection }
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
 import play.api.libs.json.Json
+
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
@@ -73,9 +75,20 @@ class PlayJsonSupportSpec
       Unmarshal(entity)
         .to[Foo]
         .failed
-        .map(
-          _ should have message """{"obj.bar":[{"msg":["error.expected.jsstring"],"args":[]}]}"""
-        )
+        .map({ err =>
+          err shouldBe a[RejectionError]
+          err match {
+            case RejectionError(
+                ValidationRejection(message, Some(PlayJsonError(error)))) =>
+              message should be(
+                """{"obj.bar":[{"msg":["error.expected.jsstring"],"args":[]}]}""")
+              error.errors should have length 1
+              error.errors.head._1.toString() should be("/bar")
+              error.errors.head._2.flatMap(_.messages) should be(
+                Seq("error.expected.jsstring"))
+            case _ => fail("Did not throw correct validation error.")
+          }
+        })
     }
 
     "fail with NoContentException when unmarshalling empty entities" in {


### PR DESCRIPTION
As discussed in #46, akka-http allows you to put more information about unmarshalling errors into the rejections.

This PR puts the original `JsError` into the `Rejection`. Unfortunately I had to create a pretty superfluous wrapper exception but I haven't found a way to avoid this.