### PR TITLE
Remove test scope from circe generic

### DIFF
--- a/akka-http-circe/build.sbt
+++ b/akka-http-circe/build.sbt
@@ -2,7 +2,7 @@ libraryDependencies ++= List(
   Library.akkaHttp,
   Library.circe,
   Library.circeJawn,
-  Library.circeGeneric % "test",
+  Library.circeGeneric,
   Library.scalaTest    % "test"
 )
 


### PR DESCRIPTION
This was preventing me from importing io.circe.generic.{...}