### PR TITLE
Add error accumulation in Circe support.

### DIFF
--- a/akka-http-circe/src/test/scala/de/heikoseeberger/akkahttpcirce/ExampleApp.scala
+++ b/akka-http-circe/src/test/scala/de/heikoseeberger/akkahttpcirce/ExampleApp.scala
@@ -39,7 +39,7 @@ object ExampleApp {
   }
 
   def route(implicit mat: Materializer) = {
-    import CirceSupport._
+    import FailFastCirceSupport._
     import Directives._
     import io.circe.generic.auto._
 


### PR DESCRIPTION
Fix #114.

I used the same pattern as in the [circe-spray](https://github.com/circe/circe-spray/blob/master/core/src/main/scala/io/circe/spray/JsonSupport.scala) implementation. This breaks backward compatibility for people extending the `CirceSupport` trait (but is okay when importing the members from the object `import CirceSupport._`).
If this isn't okay, we can add a `BaseCirceSupport` trait and make `CirceSupport` behaving exactly as its current version.

Another small change, the marshaller now requires a `RootEncoder` instead of `Encoder`, which is needed to ensure correctness.  