### PR TITLE
Allow control of Play JSON formatting

### DIFF
--- a/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
+++ b/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
@@ -74,6 +74,9 @@ trait PlayJsonSupport {
     * @tparam A type to encode
     * @return marshaller for any `A` value
     */
-  implicit def marshaller[A: Writes]: ToEntityMarshaller[A] =
-    jsonStringMarshaller.compose(Json.prettyPrint).compose(implicitly[Writes[A]].writes)
+  implicit def marshaller[A](
+      implicit writes: Writes[A],
+      printer: JsValue => String = Json.prettyPrint
+  ): ToEntityMarshaller[A] =
+    jsonStringMarshaller.compose(printer).compose(writes.writes)
 }


### PR DESCRIPTION
This addresses #135 by restoring the ability to send in a custom JsValue
printer if the user wants. It continues the current default behavior
of using pretty-printed JSON. In addition to the ability explicitly
override the unparser, you can also do this by having an implicit
variable in scope of type `JsValue => String`.