### PR TITLE
Add possiblity to override unmarshaller content types

### DIFF
--- a/akka-http-argonaut/src/main/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupport.scala
+++ b/akka-http-argonaut/src/main/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupport.scala
@@ -17,10 +17,12 @@
 package de.heikoseeberger.akkahttpargonaut
 
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
+import akka.http.scaladsl.model.ContentTypeRange
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
 import argonaut.{ DecodeJson, EncodeJson, Json, Parse, PrettyParams }
+import scala.collection.immutable.Seq
 
 /**
   * Automatic to and from JSON marshalling/unmarshalling using an in-scope *Argonaut* protocol.
@@ -36,9 +38,12 @@ object ArgonautSupport extends ArgonautSupport
   */
 trait ArgonautSupport {
 
+  def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    Seq(`application/json`)
+
   private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
-      .forContentTypes(`application/json`)
+      .forContentTypes(unmarshallerContentTypes: _*)
       .mapWithCharset {
         case (ByteString.empty, _) => throw Unmarshaller.NoContentException
         case (data, charset)       => data.decodeString(charset.nioCharset.name)

--- a/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
+++ b/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
@@ -17,11 +17,12 @@
 package de.heikoseeberger.akkahttpcirce
 
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
-import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.{ ContentTypeRange, HttpEntity }
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
 import io.circe.{ jawn, Decoder, Encoder, Errors, Json, Printer }
+import scala.collection.immutable.Seq
 
 /**
   * Automatic to and from JSON marshalling/unmarshalling using an in-scope circe protocol.
@@ -71,6 +72,9 @@ trait CirceSupport extends FailFastCirceSupport
   */
 trait BaseCirceSupport {
 
+  def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    Seq(`application/json`)
+
   /**
     * Printer used in the JSON marshaller.
     */
@@ -102,7 +106,7 @@ trait BaseCirceSupport {
     */
   implicit final val jsonUnmarshaller: FromEntityUnmarshaller[Json] =
     Unmarshaller.byteStringUnmarshaller
-      .forContentTypes(`application/json`)
+      .forContentTypes(unmarshallerContentTypes: _*)
       .map {
         case ByteString.empty => throw Unmarshaller.NoContentException
         case data             => jawn.parseByteBuffer(data.asByteBuffer).fold(throw _, identity)

--- a/akka-http-jackson/src/main/scala/de/heikoseeberger/akkahttpjackson/JacksonSupport.scala
+++ b/akka-http-jackson/src/main/scala/de/heikoseeberger/akkahttpjackson/JacksonSupport.scala
@@ -18,11 +18,14 @@ package de.heikoseeberger.akkahttpjackson
 
 import akka.http.javadsl.marshallers.jackson.Jackson
 import akka.http.scaladsl.marshalling._
+import akka.http.scaladsl.model.ContentTypeRange
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import scala.collection.immutable.Seq
+
 import scala.reflect.ClassTag
 
 /**
@@ -39,9 +42,12 @@ object JacksonSupport extends JacksonSupport {
 trait JacksonSupport {
   import JacksonSupport._
 
+  def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    Seq(`application/json`)
+
   private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
-      .forContentTypes(`application/json`)
+      .forContentTypes(unmarshallerContentTypes: _*)
       .mapWithCharset {
         case (ByteString.empty, _) => throw Unmarshaller.NoContentException
         case (data, charset)       => data.decodeString(charset.nioCharset.name)

--- a/akka-http-json4s/src/main/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupport.scala
+++ b/akka-http-json4s/src/main/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupport.scala
@@ -17,11 +17,14 @@
 package de.heikoseeberger.akkahttpjson4s
 
 import java.lang.reflect.InvocationTargetException
+
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
+import akka.http.scaladsl.model.ContentTypeRange
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
 import org.json4s.{ Formats, MappingException, Serialization }
+import scala.collection.immutable.Seq
 
 /**
   * Automatic to and from JSON marshalling/unmarshalling using an in-scope *Json4s* protocol.
@@ -46,9 +49,12 @@ object Json4sSupport extends Json4sSupport {
 trait Json4sSupport {
   import Json4sSupport._
 
+  def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    Seq(`application/json`)
+
   private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
-      .forContentTypes(`application/json`)
+      .forContentTypes(unmarshallerContentTypes: _*)
       .mapWithCharset {
         case (ByteString.empty, _) => throw Unmarshaller.NoContentException
         case (data, charset)       => data.decodeString(charset.nioCharset.name)

--- a/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
+++ b/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
@@ -17,11 +17,13 @@
 package de.heikoseeberger.akkahttpplayjson
 
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
+import akka.http.scaladsl.model.ContentTypeRange
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.server.{ RejectionError, ValidationRejection }
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
 import play.api.libs.json.{ JsError, JsValue, Json, Reads, Writes }
+import scala.collection.immutable.Seq
 
 /**
   * Automatic to and from JSON marshalling/unmarshalling using an in-scope *play-json* protocol.
@@ -40,9 +42,12 @@ object PlayJsonSupport extends PlayJsonSupport {
 trait PlayJsonSupport {
   import PlayJsonSupport._
 
+  def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    Seq(`application/json`)
+
   private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
-      .forContentTypes(`application/json`)
+      .forContentTypes(unmarshallerContentTypes: _*)
       .mapWithCharset {
         case (ByteString.empty, _) => throw Unmarshaller.NoContentException
         case (data, charset)       => data.decodeString(charset.nioCharset.name)

--- a/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleSupport.scala
+++ b/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleSupport.scala
@@ -17,11 +17,13 @@
 package de.heikoseeberger.akkahttpupickle
 
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
+import akka.http.scaladsl.model.ContentTypeRange
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
 import upickle.default.{ readJs, writeJs, Reader, Writer }
 import upickle.{ json, Js }
+import scala.collection.immutable.Seq
 
 /**
   * Automatic to and from JSON marshalling/unmarshalling using *upickle* protocol.
@@ -33,9 +35,12 @@ object UpickleSupport extends UpickleSupport
   */
 trait UpickleSupport {
 
+  def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    Seq(`application/json`)
+
   private val jsonStringUnmarshaller =
     Unmarshaller.byteStringUnmarshaller
-      .forContentTypes(`application/json`)
+      .forContentTypes(unmarshallerContentTypes: _*)
       .mapWithCharset {
         case (ByteString.empty, _) => throw Unmarshaller.NoContentException
         case (data, charset)       => data.decodeString(charset.nioCharset.name)

--- a/akka-http-upickle/src/test/scala/de/heikoseeberger/akkahttpupickle/UpickleSupportSpec.scala
+++ b/akka-http-upickle/src/test/scala/de/heikoseeberger/akkahttpupickle/UpickleSupportSpec.scala
@@ -19,11 +19,13 @@ package de.heikoseeberger.akkahttpupickle
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.ContentTypes.`application/json`
-import akka.http.scaladsl.model.{ HttpEntity, MediaTypes, RequestEntity }
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
 import akka.stream.ActorMaterializer
 import org.scalatest.{ AsyncWordSpec, BeforeAndAfterAll, Matchers }
+
+import scala.collection.immutable.Seq
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
@@ -69,6 +71,25 @@ class UpickleSupportSpec extends AsyncWordSpec with Matchers with BeforeAndAfter
         .to[Foo]
         .failed
         .map(_ shouldBe UnsupportedContentTypeException(`application/json`))
+    }
+
+    "allow unmarshalling with passed in Content-Types" in {
+      val foo = Foo("bar")
+      val `application/json-home` =
+        MediaType.applicationWithFixedCharset("json-home", HttpCharsets.`UTF-8`, "json-home")
+
+      object CustomUpickleSupport extends UpickleSupport {
+        override def unmarshallerContentTypes: Seq[ContentTypeRange] =
+          Seq(`application/json`, `application/json-home`)
+      }
+
+      import CustomUpickleSupport._
+
+      val entity =
+        HttpEntity(`application/json-home`, """{ "bar": "bar" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .map(_ shouldBe foo)
     }
   }
 


### PR DESCRIPTION
This PR changes the traits to define a Seq[ContentTypeRange] which allows the client to override the Content-Types accepted for unmarshalling. This is useful if [json home documents](https://tools.ietf.org/html/draft-nottingham-json-home-06) are used which use Content-Type `application/json-home`