### PR TITLE
Making Circe error accumulating DecodingFailures publicly accessible

### DIFF
--- a/akka-http-circe/src/test/scala/de/heikoseeberger/akkahttpcirce/CirceSupportSpec.scala
+++ b/akka-http-circe/src/test/scala/de/heikoseeberger/akkahttpcirce/CirceSupportSpec.scala
@@ -147,7 +147,7 @@ final class CirceSupportSpec extends AsyncWordSpec with Matchers with BeforeAndA
           DecodingFailure("String", List(DownField("a"))),
           DecodingFailure("String", List(DownField("b")))
         )
-      val errorMessage = new ErrorAccumulatingUnmarshaller.DecodingFailures(errors).getMessage
+      val errorMessage = ErrorAccumulatingCirceSupport.DecodingFailures(errors).getMessage
       Unmarshal(entity)
         .to[MultiFoo]
         .failed


### PR DESCRIPTION
Allowing to access `DecodingFailures` within a `RejectionHandler` so the output error could be customised.

https://github.com/hseeberger/akka-http-json/issues/157