### PR TITLE
Pretty-printing decoding failures in akka-http-circe

### DIFF
--- a/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
+++ b/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
@@ -22,7 +22,8 @@ import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
 import cats.data.NonEmptyList
-import io.circe.{ jawn, Decoder, DecodingFailure, Encoder, Errors, Json, Printer }
+import cats.syntax.show.toShowOps
+import io.circe.{ jawn, Decoder, DecodingFailure, Encoder, Json, Printer }
 import scala.collection.immutable.Seq
 
 /**
@@ -49,7 +50,7 @@ trait FailFastCirceSupport extends BaseCirceSupport with FailFastUnmarshaller
   */
 object ErrorAccumulatingCirceSupport extends ErrorAccumulatingCirceSupport {
   final case class DecodingFailures(failures: NonEmptyList[DecodingFailure]) extends Exception {
-    override def getMessage = failures.toList.map(_.getMessage).mkString("\n")
+    override def getMessage: String = failures.toList.map(_.show).mkString("\n")
   }
 }
 

--- a/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
+++ b/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
@@ -50,7 +50,7 @@ trait FailFastCirceSupport extends BaseCirceSupport with FailFastUnmarshaller
   */
 object ErrorAccumulatingCirceSupport extends ErrorAccumulatingCirceSupport {
   final case class DecodingFailures(failures: NonEmptyList[DecodingFailure]) extends Exception {
-    override def getMessage: String = failures.toList.map(_.show).mkString("\n")
+    override def getMessage = failures.toList.map(_.show).mkString("\n")
   }
 }
 


### PR DESCRIPTION
Circe provides instance of type class `cats.Show` for `Error` with prettier text.

So we can make better error message for `DecodingFailure`

For instance, following message

```
The request content was malformed:
Attempt to decode value on failed cursor: DownField(foo),DownField(bar)
```

Will be changed to

```
The request content was malformed:
DecodingFailure at .foo.bar: Attempt to decode value on failed cursor
```

Ref. https://github.com/circe/circe/pull/222