### PR TITLE
Upgrade circe to 0.9.0-M1

### DIFF
--- a/akka-http-circe/src/test/scala/de/heikoseeberger/akkahttpcirce/CirceSupportSpec.scala
+++ b/akka-http-circe/src/test/scala/de/heikoseeberger/akkahttpcirce/CirceSupportSpec.scala
@@ -98,7 +98,7 @@ final class CirceSupportSpec extends AsyncWordSpec with Matchers with BeforeAndA
     }
 
     "not write None" in {
-      implicit val printer = Printer.noSpaces.copy(dropNullKeys = true)
+      implicit val printer = Printer.noSpaces.copy(dropNullValues = true)
       val optionFoo        = OptionFoo(None)
       Marshal(optionFoo)
         .to[RequestEntity]

--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ lazy val library =
     object Version {
       val akkaHttp     = "10.0.9"
       val argonaut     = "6.2"
-      val circe        = "0.8.0"
+      val circe        = "0.9.0-M1"
       val jacksonScala = "2.9.0"
       val json4s       = "3.5.3"
       val play         = "2.6.3"


### PR DESCRIPTION
Circe 0.9.0-M1 was published recently. It is the first circe release using cats 1.0.0-MF. It would be good to have a corresponding akka-http-circe version out, so that people could check their applications for potential problems ahead of cats 1.0.0 releases.