### PR TITLE
Media types can be overridden for both marshaller and unmarshaller

### DIFF
--- a/akka-http-argonaut/src/main/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupport.scala
+++ b/akka-http-argonaut/src/main/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupport.scala
@@ -18,6 +18,7 @@ package de.heikoseeberger.akkahttpargonaut
 
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import akka.http.scaladsl.model.ContentTypeRange
+import akka.http.scaladsl.model.MediaType
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
@@ -39,6 +40,9 @@ object ArgonautSupport extends ArgonautSupport
 trait ArgonautSupport {
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    mediaTypes.map(ContentTypeRange.apply)
+
+  def mediaTypes: Seq[MediaType.WithFixedCharset] =
     List(`application/json`)
 
   private val jsonStringUnmarshaller =
@@ -49,7 +53,8 @@ trait ArgonautSupport {
         case (data, charset)       => data.decodeString(charset.nioCharset.name)
       }
 
-  private val jsonStringMarshaller = Marshaller.stringMarshaller(`application/json`)
+  private val jsonStringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(Marshaller.stringMarshaller)
 
   /**
     * HTTP entity => `A`

--- a/akka-http-avro4s/src/main/scala/de/heikoseeberger/akkahttpavro4s/AvroSupport.scala
+++ b/akka-http-avro4s/src/main/scala/de/heikoseeberger/akkahttpavro4s/AvroSupport.scala
@@ -20,6 +20,7 @@ import java.io.{ ByteArrayOutputStream, IOException }
 
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import akka.http.scaladsl.model.ContentTypeRange
+import akka.http.scaladsl.model.MediaType
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
@@ -40,6 +41,9 @@ object AvroSupport extends AvroSupport
 trait AvroSupport {
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    mediaTypes.map(ContentTypeRange.apply)
+
+  def mediaTypes: Seq[MediaType.WithFixedCharset] =
     List(`application/json`)
 
   private val jsonStringUnmarshaller =
@@ -50,7 +54,8 @@ trait AvroSupport {
         case (data, charset)       => data.decodeString(charset.nioCharset.name)
       }
 
-  private val jsonStringMarshaller = Marshaller.stringMarshaller(`application/json`)
+  private val jsonStringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(Marshaller.stringMarshaller)
 
   /**
     * HTTP entity => `A`

--- a/akka-http-json4s/src/main/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupport.scala
+++ b/akka-http-json4s/src/main/scala/de/heikoseeberger/akkahttpjson4s/Json4sSupport.scala
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationTargetException
 
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import akka.http.scaladsl.model.ContentTypeRange
+import akka.http.scaladsl.model.MediaType
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
@@ -50,6 +51,9 @@ trait Json4sSupport {
   import Json4sSupport._
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    mediaTypes.map(ContentTypeRange.apply)
+
+  def mediaTypes: Seq[MediaType.WithFixedCharset] =
     List(`application/json`)
 
   private val jsonStringUnmarshaller =
@@ -60,7 +64,8 @@ trait Json4sSupport {
         case (data, charset)       => data.decodeString(charset.nioCharset.name)
       }
 
-  private val jsonStringMarshaller = Marshaller.stringMarshaller(`application/json`)
+  private val jsonStringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(Marshaller.stringMarshaller)
 
   /**
     * HTTP entity => `A`

--- a/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
+++ b/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
@@ -18,6 +18,7 @@ package de.heikoseeberger.akkahttpplayjson
 
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import akka.http.scaladsl.model.ContentTypeRange
+import akka.http.scaladsl.model.MediaType
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.server.{ RejectionError, ValidationRejection }
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
@@ -43,6 +44,9 @@ trait PlayJsonSupport {
   import PlayJsonSupport._
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    mediaTypes.map(ContentTypeRange.apply)
+
+  def mediaTypes: Seq[MediaType.WithFixedCharset] =
     List(`application/json`)
 
   private val jsonStringUnmarshaller =
@@ -53,7 +57,8 @@ trait PlayJsonSupport {
         case (data, charset)       => data.decodeString(charset.nioCharset.name)
       }
 
-  private val jsonStringMarshaller = Marshaller.stringMarshaller(`application/json`)
+  private val jsonStringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(Marshaller.stringMarshaller)
 
   /**
     * HTTP entity => `A`

--- a/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleSupport.scala
+++ b/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleSupport.scala
@@ -18,6 +18,7 @@ package de.heikoseeberger.akkahttpupickle
 
 import akka.http.scaladsl.marshalling.{ Marshaller, ToEntityMarshaller }
 import akka.http.scaladsl.model.ContentTypeRange
+import akka.http.scaladsl.model.MediaType
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
@@ -36,6 +37,9 @@ object UpickleSupport extends UpickleSupport
 trait UpickleSupport {
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    mediaTypes.map(ContentTypeRange.apply)
+
+  def mediaTypes: Seq[MediaType.WithFixedCharset] =
     List(`application/json`)
 
   private val jsonStringUnmarshaller =
@@ -46,7 +50,8 @@ trait UpickleSupport {
         case (data, charset)       => data.decodeString(charset.nioCharset.name)
       }
 
-  private val jsonStringMarshaller = Marshaller.stringMarshaller(`application/json`)
+  private val jsonStringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(Marshaller.stringMarshaller)
 
   /**
     * HTTP entity => `A`


### PR DESCRIPTION
See Issue #183 

`unmarshallerContentTypes` retains previous signature, but are now built from `mediaTypes`.
Overriding only `mediaTypes` will affect both marshaller and unmarshaller.

Implemented for all `*Support` traits except for Jackson, where no simple way is available to change marshaller content type.