### PR TITLE
Bump circe version to 0.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ lazy val library =
     object Version {
       val akkaHttp     = "10.0.11"
       val argonaut     = "6.2"
-      val circe        = "0.9.0-M3"
+      val circe        = "0.9.0"
       val jacksonScala = "2.9.2"
       val json4s       = "3.5.3"
       val play         = "2.6.8"


### PR DESCRIPTION
Hi,
I just bumped the version to the final circe 0.9.0 release, so we can upgrade our akka-http application soon :)

(This version bump is in compliance with the contribution policy)