### PR TITLE
Summon type-classes implicit instances using library provided methods

### DIFF
--- a/akka-http-argonaut/src/main/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupport.scala
+++ b/akka-http-argonaut/src/main/scala/de/heikoseeberger/akkahttpargonaut/ArgonautSupport.scala
@@ -69,7 +69,7 @@ trait ArgonautSupport {
         case Left(message) => sys.error(message)
       }
     def decode(json: Json) =
-      implicitly[DecodeJson[A]].decodeJson(json).result match {
+      DecodeJson.of[A].decodeJson(json).result match {
         case Right(entity) => entity
         case Left((m, h))  => sys.error(m + " - " + h)
       }
@@ -85,5 +85,5 @@ trait ArgonautSupport {
   implicit def marshaller[A: EncodeJson]: ToEntityMarshaller[A] =
     jsonStringMarshaller
       .compose(PrettyParams.nospace.pretty)
-      .compose(implicitly[EncodeJson[A]].apply)
+      .compose(EncodeJson.of[A].apply)
 }

--- a/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
+++ b/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
@@ -97,7 +97,7 @@ trait BaseCirceSupport {
   implicit final def marshaller[A: Encoder](
       implicit printer: Printer = Printer.noSpaces
   ): ToEntityMarshaller[A] =
-    jsonMarshaller(printer).compose(implicitly[Encoder[A]].apply)
+    jsonMarshaller(printer).compose(Encoder[A].apply)
 
   /**
     * HTTP entity => `Json`
@@ -127,7 +127,7 @@ trait BaseCirceSupport {
 trait FailFastUnmarshaller { this: BaseCirceSupport =>
 
   override implicit final def unmarshaller[A: Decoder]: FromEntityUnmarshaller[A] = {
-    def decode(json: Json) = implicitly[Decoder[A]].decodeJson(json).fold(throw _, identity)
+    def decode(json: Json) = Decoder[A].decodeJson(json).fold(throw _, identity)
     jsonUnmarshaller.map(decode)
   }
 }
@@ -139,7 +139,7 @@ trait ErrorAccumulatingUnmarshaller { this: BaseCirceSupport =>
 
   override implicit final def unmarshaller[A: Decoder]: FromEntityUnmarshaller[A] = {
     def decode(json: Json) =
-      implicitly[Decoder[A]]
+      Decoder[A]
         .accumulating(json.hcursor)
         .fold(failures => throw ErrorAccumulatingCirceSupport.DecodingFailures(failures), identity)
     jsonUnmarshaller.map(decode)


### PR DESCRIPTION
Some code summons instances using `implicitly` where the library provides `apply` or `of` for these cases. The PR uses the library provided way instead of `implicitly`. Not a big deal though.