### PR TITLE
Bump akka

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,7 +152,7 @@ lazy val `akka-http-avsystem-gencodec` =
 lazy val library =
   new {
     object Version {
-      val akka             = "2.5.16"
+      val akka             = "2.5.17"
       val akkaHttp         = "10.1.5"
       val argonaut         = "6.2.2"
       val avro4s           = "1.9.0"


### PR DESCRIPTION
Blog post: https://akka.io/blog/news/2018/09/27/akka-2.5.17-released