### PR TITLE
Bump scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
   - 2.11.11
-  - 2.12.6
+  - 2.12.7
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Release notes: https://github.com/scala/scala/releases/tag/v2.12.7

> Compiler performance has improved significantly again, and is mostly on par with 2.13. Concretely, you should see a 10% drop in compile times since 2.12.6, according to our compiler benchmarks.