### PR TITLE
Update jackson-module-scala to 2.9.8 and upickle to 0.7.1

### DIFF
--- a/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleSupport.scala
+++ b/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleSupport.scala
@@ -22,8 +22,7 @@ import akka.http.scaladsl.model.MediaType
 import akka.http.scaladsl.model.MediaTypes.`application/json`
 import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshaller }
 import akka.util.ByteString
-import upickle.default.{ Reader, Writer, readJs, writeJs }
-import upickle.{ Js, json }
+import upickle.default.{ Reader, Writer, read, write }
 import scala.collection.immutable.Seq
 
 /**
@@ -60,7 +59,7 @@ trait UpickleSupport {
     * @return unmarshaller for `A`
     */
   implicit def unmarshaller[A: Reader]: FromEntityUnmarshaller[A] =
-    jsonStringUnmarshaller.map(data => readJs[A](json.read(data)))
+    jsonStringUnmarshaller.map(read(_))
 
   /**
     * `A` => HTTP entity
@@ -69,5 +68,5 @@ trait UpickleSupport {
     * @return marshaller for any `A` value
     */
   implicit def marshaller[A: Writer]: ToEntityMarshaller[A] =
-    jsonStringMarshaller.compose(json.write(_: Js.Value, 0)).compose(writeJs[A])
+    jsonStringMarshaller.compose(write(_))
 }

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,7 @@ lazy val `akka-http-jackson` =
         library.akkaStream,
         library.akkaHttpJacksonJava,
         library.jacksonModuleScala,
+        "org.scala-lang" % "scala-reflect" % scalaVersion.value,
         library.scalaTest % Test
       )
     )
@@ -157,12 +158,12 @@ lazy val library =
       val argonaut            = "6.2.2"
       val avro4s              = "1.9.0"
       val circe               = "0.11.0"
-      val jacksonModuleScala  = "2.9.6"
+      val jacksonModuleScala  = "2.9.8"
       val jsoniterScalaMacros = "0.37.6"
       val json4s              = "3.6.2"
       val play                = "2.6.13"
       val scalaTest           = "3.0.5"
-      val upickle             = "0.6.7"
+      val upickle             = "0.7.1"
       val avsystemCommons     = "1.34.6"
     }
     val akkaHttp            = "com.typesafe.akka"                     %% "akka-http"             % Version.akkaHttp


### PR DESCRIPTION
Fixes build failures in https://github.com/hseeberger/akka-http-json/pull/233 and https://github.com/hseeberger/akka-http-json/pull/226