### PR TITLE
Avoid roundtrip through String when marshalling with Circe

### DIFF
--- a/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
+++ b/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
@@ -84,7 +84,7 @@ trait BaseCirceSupport {
   ): ToEntityMarshaller[Json] =
     Marshaller.oneOf(mediaTypes: _*) { mediaType =>
       Marshaller.withFixedContentType(ContentType(mediaType)) { json =>
-        HttpEntity(mediaType, printer.pretty(json))
+        HttpEntity(mediaType, ByteString(printer.prettyByteBuffer(json, mediaType.charset.nioCharset())))
       }
     }
 


### PR DESCRIPTION
By making an HttpEntity from a ByteString instead of a String, we avoid
the need to allocate a String, only to end up converting it to bytes
to send on the wire.