### PR TITLE
Add sbt-ci-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,32 @@ scala:
 
 jdk:
   - oraclejdk8
+
+stages:
+  - name: test
+  - name: release
+    if: tag IS present
+
+jobs:
+  include:
+    - script: sbt test:compile test
+    - stage: release
+      script: sbt ci-release
+
+cache:
+  directories:
+    - $HOME/.sbt/1.0/dependency
+    - $HOME/.sbt/boot/scala*
+    - $HOME/.sbt/launchers
+    - $HOME/.ivy2/cache
+    - $HOME/.coursier
+
+before_cache:
+  - du -h -d 1 $HOME/.ivy2/cache
+  - du -h -d 2 $HOME/.sbt/
+  - find $HOME/.sbt -name "*.lock" -type f -delete
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
+  - rm -rf $HOME/.ivy2/local
+
+before_install:
+  - git fetch --tags

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 inThisBuild(
   List(
-    organization := "de.hseeberger",
+    organization := "de.heikoseeberger",
     homepage := Some(url("https://github.com/hseeberger/akka-http-json")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     scmInfo := Some(

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,21 @@
+inThisBuild(
+  List(
+    organization := "de.hseeberger",
+    homepage := Some(url("https://github.com/hseeberger/akka-http-json")),
+    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    scmInfo := Some(
+      ScmInfo(url("https://github.com/hseeberger/akka-http-json"),
+              "git@github.com:hseeberger/akka-http-json.git")
+    ),
+    developers := List(
+      Developer("hseeberger",
+                "Heiko Seeberger",
+                "mail@heikoseeberger.de",
+                url("https://github.com/hseeberger"))
+    )
+  )
+)
+
 // *****************************************************************************
 // Projects
 // *****************************************************************************
@@ -199,10 +217,8 @@ lazy val commonSettings =
   Seq(
     // scalaVersion from .travis.yml via sbt-travisci
     // scalaVersion := "2.12.3",
-    organization := "de.heikoseeberger",
     organizationName := "Heiko Seeberger",
     startYear := Some(2015),
-    licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     scalacOptions ++= Seq(
       "-unchecked",
       "-deprecation",
@@ -226,13 +242,5 @@ lazy val scalafmtSettings =
 
 lazy val publishSettings =
   Seq(
-    homepage := Some(url("https://github.com/hseeberger/akka-http-json")),
-    scmInfo := Some(ScmInfo(url("https://github.com/hseeberger/akka-http-json"),
-                            "git@github.com:hseeberger/akka-http-json.git")),
-    developers += Developer("hseeberger",
-                            "Heiko Seeberger",
-                            "mail@heikoseeberger.de",
-                            url("https://github.com/hseeberger")),
     pomIncludeRepository := (_ => false),
-    bintrayPackage := "akka-http-json"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ inThisBuild(
 lazy val `akka-http-json` =
   project
     .in(file("."))
-    .enablePlugins(GitVersioning)
     .aggregate(
       `akka-http-argonaut`,
       `akka-http-circe`,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,6 @@
-addSbtPlugin("com.dwijnand"      % "sbt-travisci" % "1.1.3")
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.1.2")
-addSbtPlugin("com.geirsson"      % "sbt-scalafmt" % "1.5.0")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-git"      % "1.0.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.0.0")
-addSbtPlugin("org.foundweekends" % "sbt-bintray"  % "0.5.4")
+addSbtPlugin("com.geirsson"      % "sbt-ci-release" % "1.2.1")
+addSbtPlugin("com.dwijnand"      % "sbt-travisci"  % "1.1.3")
+addSbtPlugin("com.geirsson"      % "sbt-scalafmt"  % "1.5.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"    % "5.0.0")
 
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.25" // Needed by sbt-git


### PR DESCRIPTION
I changed the Travis file to make a release on every tag (tagging with e.g. `v0.1.0` will release version `0.1.0`).

Also, I removed bintray integration because it was conflicting with `publish`, and I don't know if you still need it (let me know if you do). After merging this, you need to set sonatype credentials as env variables in Travis, as well as the pgp key's passphrase and the secret key itself (the public one must be uploaded to a key server). Basically the instructions from https://github.com/olafurpg/sbt-ci-release#gpg should be followed.

Let me know if you need help with this, and I'll try to provide some :)