### PR TITLE
Fix #270 to preserve error information in structured form

### DIFF
--- a/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
+++ b/akka-http-play-json/src/main/scala/de/heikoseeberger/akkahttpplayjson/PlayJsonSupport.scala
@@ -28,12 +28,18 @@ import scala.collection.immutable.Seq
 /**
   * Automatic to and from JSON marshalling/unmarshalling using an in-scope *play-json* protocol.
   */
-object PlayJsonSupport extends PlayJsonSupport
+object PlayJsonSupport extends PlayJsonSupport {
+  final case class PlayJsonError(error: JsError) extends IllegalArgumentException {
+    override def getMessage: String =
+      JsError.toJson(error).toString()
+  }
+}
 
 /**
   * Automatic to and from JSON marshalling/unmarshalling using an in-scope *play-json* protocol.
   */
 trait PlayJsonSupport {
+  import PlayJsonSupport._
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] =
     mediaTypes.map(ContentTypeRange.apply)
@@ -63,7 +69,7 @@ trait PlayJsonSupport {
       implicitly[Reads[A]]
         .reads(json)
         .recoverTotal { e =>
-          throw new IllegalArgumentException(JsError.toJson(e).toString)
+          throw PlayJsonError(e)
         }
     jsonStringUnmarshaller.map(data => read(Json.parse(data)))
   }


### PR DESCRIPTION
By stringifying the error and throwing a generic `IllegalArgumentException`, #270 breaks applications that want to catch the play-json error and use the structured error data.

This commit brings back the `PlayJsonError` containing the play-json `JsError`, but throws it directly instead of wrapping it in a `RejectionError` like #96 did. When used in a server, akka-http's `entity` directive will catch an `IllegalArgumentException` (or subclass) and wrap it in a `ValidationRejection`, so this preserves the pre-#270 behavior for akka-http servers.

Partial revert of #270 (835e74dabf12fb1553489ac2a5459649ec0b48b7)