### PR TITLE
Support scala 2.13 for akka-http-circe

### DIFF
--- a/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
+++ b/akka-http-circe/src/main/scala/de/heikoseeberger/akkahttpcirce/CirceSupport.scala
@@ -160,7 +160,7 @@ trait ErrorAccumulatingUnmarshaller { this: BaseCirceSupport =>
   override implicit final def unmarshaller[A: Decoder]: FromEntityUnmarshaller[A] = {
     def decode(json: Json) =
       Decoder[A]
-        .accumulating(json.hcursor)
+        .decodeAccumulating(json.hcursor)
         .fold(failures => throw ErrorAccumulatingCirceSupport.DecodingFailures(failures), identity)
     jsonUnmarshaller.map(decode)
   }
@@ -169,7 +169,7 @@ trait ErrorAccumulatingUnmarshaller { this: BaseCirceSupport =>
     : FromEntityUnmarshaller[ValidatedNel[io.circe.Error, A]] = {
     def decode(json: Json): ValidatedNel[io.circe.Error, A] =
       Decoder[A]
-        .accumulating(json.hcursor)
+        .decodeAccumulating(json.hcursor)
     safeJsonUnmarshaller.map(_.toValidatedNel andThen decode)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ lazy val `akka-http-circe` =
     .enablePlugins(AutomateHeaderPlugin)
     .settings(settings)
     .settings(
+      crossScalaVersions := Seq("2.13.0", scalaVersion.value, "2.11.12"),
       libraryDependencies ++= Seq(
         library.akkaHttp,
         library.akkaStream,
@@ -179,7 +180,7 @@ lazy val library =
       val akkaHttp            = "10.1.9"
       val argonaut            = "6.2.3"
       val avro4s              = "1.9.0"
-      val circe               = "0.11.1"
+      val circe               = "0.12.0-M3"
       val jacksonModuleScala  = "2.9.9"
       val jsoniterScalaMacros = "0.51.3"
       val json4s              = "3.6.6"


### PR DESCRIPTION
The 0.12.0-M3 version is the last to support all 3 versions