### PR TITLE
Add support for uPickle custom configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ stages:
 
 jobs:
   include:
-    - script: sbt -Dsbt.supershell=false +test:compile +test
+    - script: sbt -Dsbt.supershell=false +test:compile +test +mimaReportBinaryIssues
     - stage: release
       script: sbt -Dsbt.supershell=false ci-release
 

--- a/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleCustomizationSupport.scala
+++ b/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleCustomizationSupport.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.akkahttpupickle
+
+import akka.http.javadsl.common.JsonEntityStreamingSupport
+import akka.http.scaladsl.common.EntityStreamingSupport
+import akka.http.scaladsl.marshalling.{ Marshaller, Marshalling, ToEntityMarshaller }
+import akka.http.scaladsl.model.{ ContentTypeRange, HttpEntity, MediaType, MessageEntity }
+import akka.http.scaladsl.model.MediaTypes.`application/json`
+import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshal, Unmarshaller }
+import akka.http.scaladsl.util.FastFuture
+import akka.stream.scaladsl.{ Flow, Source }
+import akka.util.ByteString
+
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+import scala.util.Try
+import scala.util.control.NonFatal
+
+/**
+  * Automatic to and from JSON marshalling/unmarshalling using *upickle* protocol.
+  */
+trait UpickleCustomizationSupport {
+  type SourceOf[A] = Source[A, _]
+
+  type Api <: upickle.Api
+
+  def api: Api
+
+  private lazy val apiInstance: Api = api
+
+  def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    mediaTypes.map(ContentTypeRange.apply)
+
+  def mediaTypes: Seq[MediaType.WithFixedCharset] =
+    List(`application/json`)
+
+  private val jsonStringUnmarshaller =
+    Unmarshaller.byteStringUnmarshaller
+      .forContentTypes(unmarshallerContentTypes: _*)
+      .mapWithCharset {
+        case (ByteString.empty, _) => throw Unmarshaller.NoContentException
+        case (data, charset)       => data.decodeString(charset.nioCharset.name)
+      }
+
+  private def sourceByteStringMarshaller(
+      mediaType: MediaType.WithFixedCharset
+  ): Marshaller[SourceOf[ByteString], MessageEntity] =
+    Marshaller[SourceOf[ByteString], MessageEntity] { implicit ec => value =>
+      try FastFuture.successful {
+        Marshalling.WithFixedContentType(
+          mediaType,
+          () => HttpEntity(contentType = mediaType, data = value)
+        ) :: Nil
+      } catch {
+        case NonFatal(e) => FastFuture.failed(e)
+      }
+    }
+
+  private val jsonSourceStringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(sourceByteStringMarshaller)
+
+  private val jsonStringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(Marshaller.stringMarshaller)
+
+  private def jsonSource[A](entitySource: SourceOf[A])(
+      implicit writes: apiInstance.Writer[A],
+      support: JsonEntityStreamingSupport
+  ): SourceOf[ByteString] =
+    entitySource
+      .map(apiInstance.write(_))
+      .map(ByteString(_))
+      .via(support.framingRenderer)
+
+  /**
+    * `ByteString` => `A`
+    *
+    * @tparam A type to decode
+    * @return unmarshaller for any `A` value
+    */
+  implicit def fromByteStringUnmarshaller[A: apiInstance.Reader]: Unmarshaller[ByteString, A] =
+    Unmarshaller { _ => bs =>
+      Future.fromTry(Try(apiInstance.read(bs.toArray)))
+    }
+
+  /**
+    * HTTP entity => `A`
+    *
+    * @tparam A type to decode
+    * @return unmarshaller for `A`
+    */
+  implicit def unmarshaller[A: apiInstance.Reader]: FromEntityUnmarshaller[A] =
+    jsonStringUnmarshaller.map(apiInstance.read(_))
+
+  /**
+    * `A` => HTTP entity
+    *
+    * @tparam A type to encode
+    * @return marshaller for any `A` value
+    */
+  implicit def marshaller[A: apiInstance.Writer]: ToEntityMarshaller[A] =
+    jsonStringMarshaller.compose(apiInstance.write(_))
+
+  /**
+    * HTTP entity => `Source[A, _]`
+    *
+    * @tparam A type to decode
+    * @return unmarshaller for `Source[A, _]`
+    */
+  implicit def sourceUnmarshaller[A: apiInstance.Reader](
+      implicit support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
+  ): FromEntityUnmarshaller[SourceOf[A]] =
+    Unmarshaller
+      .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        def asyncParse(bs: ByteString) =
+          Unmarshal(bs).to[A]
+
+        def ordered =
+          Flow[ByteString].mapAsync(support.parallelism)(asyncParse)
+
+        def unordered =
+          Flow[ByteString].mapAsyncUnordered(support.parallelism)(asyncParse)
+
+        Future.successful {
+          entity.dataBytes
+            .via(support.framingDecoder)
+            .via(if (support.unordered) unordered else ordered)
+        }
+      }
+      .forContentTypes(unmarshallerContentTypes: _*)
+
+  /**
+    * `SourceOf[A]` => HTTP entity
+    *
+    * @tparam A type to encode
+    * @return marshaller for any `SourceOf[A]` value
+    */
+  implicit def sourceMarshaller[A](
+      implicit writes: apiInstance.Writer[A],
+      support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
+  ): ToEntityMarshaller[SourceOf[A]] =
+    jsonSourceStringMarshaller.compose(jsonSource[A])
+}

--- a/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleSupport.scala
+++ b/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleSupport.scala
@@ -16,22 +16,6 @@
 
 package de.heikoseeberger.akkahttpupickle
 
-import akka.http.javadsl.common.JsonEntityStreamingSupport
-import akka.http.scaladsl.common.EntityStreamingSupport
-import akka.http.scaladsl.marshalling.{ Marshaller, Marshalling, ToEntityMarshaller }
-import akka.http.scaladsl.model.{ ContentTypeRange, HttpEntity, MediaType, MessageEntity }
-import akka.http.scaladsl.model.MediaTypes.`application/json`
-import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshal, Unmarshaller }
-import akka.http.scaladsl.util.FastFuture
-import akka.stream.scaladsl.{ Flow, Source }
-import akka.util.ByteString
-import upickle.default.{ Reader, Writer, read, write }
-
-import scala.collection.immutable.Seq
-import scala.concurrent.Future
-import scala.util.Try
-import scala.util.control.NonFatal
-
 /**
   * Automatic to and from JSON marshalling/unmarshalling using *upickle* protocol.
   */
@@ -40,118 +24,9 @@ object UpickleSupport extends UpickleSupport
 /**
   * Automatic to and from JSON marshalling/unmarshalling using *upickle* protocol.
   */
-trait UpickleSupport {
-  type SourceOf[A] = Source[A, _]
+trait UpickleSupport extends UpickleCustomizationSupport {
 
-  def unmarshallerContentTypes: Seq[ContentTypeRange] =
-    mediaTypes.map(ContentTypeRange.apply)
+  override type Api = upickle.default.type
 
-  def mediaTypes: Seq[MediaType.WithFixedCharset] =
-    List(`application/json`)
-
-  private val jsonStringUnmarshaller =
-    Unmarshaller.byteStringUnmarshaller
-      .forContentTypes(unmarshallerContentTypes: _*)
-      .mapWithCharset {
-        case (ByteString.empty, _) => throw Unmarshaller.NoContentException
-        case (data, charset)       => data.decodeString(charset.nioCharset.name)
-      }
-
-  private def sourceByteStringMarshaller(
-      mediaType: MediaType.WithFixedCharset
-  ): Marshaller[SourceOf[ByteString], MessageEntity] =
-    Marshaller[SourceOf[ByteString], MessageEntity] { implicit ec => value =>
-      try FastFuture.successful {
-        Marshalling.WithFixedContentType(
-          mediaType,
-          () => HttpEntity(contentType = mediaType, data = value)
-        ) :: Nil
-      } catch {
-        case NonFatal(e) => FastFuture.failed(e)
-      }
-    }
-
-  private val jsonSourceStringMarshaller =
-    Marshaller.oneOf(mediaTypes: _*)(sourceByteStringMarshaller)
-
-  private val jsonStringMarshaller =
-    Marshaller.oneOf(mediaTypes: _*)(Marshaller.stringMarshaller)
-
-  private def jsonSource[A](entitySource: SourceOf[A])(
-      implicit writes: Writer[A],
-      support: JsonEntityStreamingSupport
-  ): SourceOf[ByteString] =
-    entitySource
-      .map(write(_))
-      .map(ByteString(_))
-      .via(support.framingRenderer)
-
-  /**
-    * `ByteString` => `A`
-    *
-    * @tparam A type to decode
-    * @return unmarshaller for any `A` value
-    */
-  implicit def fromByteStringUnmarshaller[A: Reader]: Unmarshaller[ByteString, A] =
-    Unmarshaller { _ => bs =>
-      Future.fromTry(Try(read(bs.toArray)))
-    }
-
-  /**
-    * HTTP entity => `A`
-    *
-    * @tparam A type to decode
-    * @return unmarshaller for `A`
-    */
-  implicit def unmarshaller[A: Reader]: FromEntityUnmarshaller[A] =
-    jsonStringUnmarshaller.map(read(_))
-
-  /**
-    * `A` => HTTP entity
-    *
-    * @tparam A type to encode
-    * @return marshaller for any `A` value
-    */
-  implicit def marshaller[A: Writer]: ToEntityMarshaller[A] =
-    jsonStringMarshaller.compose(write(_))
-
-  /**
-    * HTTP entity => `Source[A, _]`
-    *
-    * @tparam A type to decode
-    * @return unmarshaller for `Source[A, _]`
-    */
-  implicit def sourceUnmarshaller[A: Reader](
-      implicit support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
-  ): FromEntityUnmarshaller[SourceOf[A]] =
-    Unmarshaller
-      .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
-        def asyncParse(bs: ByteString) =
-          Unmarshal(bs).to[A]
-
-        def ordered =
-          Flow[ByteString].mapAsync(support.parallelism)(asyncParse)
-
-        def unordered =
-          Flow[ByteString].mapAsyncUnordered(support.parallelism)(asyncParse)
-
-        Future.successful {
-          entity.dataBytes
-            .via(support.framingDecoder)
-            .via(if (support.unordered) unordered else ordered)
-        }
-      }
-      .forContentTypes(unmarshallerContentTypes: _*)
-
-  /**
-    * `SourceOf[A]` => HTTP entity
-    *
-    * @tparam A type to encode
-    * @return marshaller for any `SourceOf[A]` value
-    */
-  implicit def sourceMarshaller[A](
-      implicit writes: Writer[A],
-      support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
-  ): ToEntityMarshaller[SourceOf[A]] =
-    jsonSourceStringMarshaller.compose(jsonSource[A])
+  override def api: Api = upickle.default
 }

--- a/akka-http-upickle/src/test/scala/de/heikoseeberger/akkahttpupickle/UpickleCustomizationSupportSpec.scala
+++ b/akka-http-upickle/src/test/scala/de/heikoseeberger/akkahttpupickle/UpickleCustomizationSupportSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.akkahttpupickle
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.ContentTypes.{ `application/json`, `text/plain(UTF-8)` }
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
+import akka.stream.scaladsl.{ Sink, Source }
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import upickle.AttributeTagged
+import upickle.core.Visitor
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+final class UpickleCustomizationSupportSpec
+    extends AsyncWordSpec
+    with Matchers
+    with BeforeAndAfterAll {
+
+  private implicit val system = ActorSystem()
+
+  object FooApi extends AttributeTagged {
+    override implicit val IntWriter: FooApi.Writer[Int] = new Writer[Int] {
+      override def write0[V](out: Visitor[_, V], v: Int): V = out.visitString("foo", -1)
+    }
+  }
+  object UpickleFoo extends UpickleCustomizationSupport {
+    override type Api = FooApi.type
+    override def api: FooApi.type = FooApi
+  }
+
+  import UpickleFoo._
+
+  "UpickleCustomizationSupport" should {
+    "support custom configuration" in {
+      Marshal(123)
+        .to[RequestEntity]
+        .flatMap(Unmarshal(_).to[String])
+        .map(_ shouldBe "foo")
+    }
+  }
+
+  override protected def afterAll() = {
+    Await.ready(system.terminate(), 42.seconds)
+    super.afterAll()
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ inThisBuild(
 lazy val `akka-http-json` =
   project
     .in(file("."))
+    .disablePlugins(MimaPlugin)
     .aggregate(
       `akka-http-argonaut`,
       `akka-http-avro4s`,
@@ -229,7 +230,8 @@ lazy val commonSettings =
       "-encoding", "UTF-8"
     ),
     Compile / unmanagedSourceDirectories := Seq((Compile / scalaSource).value),
-    Test / unmanagedSourceDirectories := Seq((Test / scalaSource).value)
+    Test / unmanagedSourceDirectories := Seq((Test / scalaSource).value),
+    mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% name.value % _).toSet,
 )
 
 lazy val gitSettings =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
-addSbtPlugin("com.geirsson"      % "sbt-ci-release" % "1.5.0")
-addSbtPlugin("com.geirsson"      % "sbt-scalafmt"   % "1.5.1")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"     % "5.4.0")
+addSbtPlugin("com.geirsson"      % "sbt-ci-release"  % "1.5.0")
+addSbtPlugin("com.geirsson"      % "sbt-scalafmt"    % "1.5.1")
+addSbtPlugin("com.typesafe"      % "sbt-mima-plugin" % "0.6.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"      % "5.4.0")
 
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.30" // Needed by sbt-git


### PR DESCRIPTION
In order to support [uPickle custom configuration](http://www.lihaoyi.com/upickle/#CustomConfiguration) one needs to be able to provide a custom instance of `Api` or `AttributeTagged`.

This solution is a little ugly but it was the best way that I could come up with which was binary compatible (and I think also source compatible 🤞).