### PR TITLE
Support for ninny json

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ akka-http-json provides JSON (un)marshalling support for [Akka HTTP](https://git
 - [Jackson](https://github.com/FasterXML/jackson) via [Scala Module](https://github.com/FasterXML/jackson-module-scala) by default
 - [Json4s](https://github.com/json4s/json4s)
 - [jsoniter-scala](https://github.com/plokhotnyuk/jsoniter-scala)
+- [ninny](https://github.com/kag0/ninny-json)
 - [Play JSON](https://www.playframework.com/documentation/2.6.x/ScalaJson)
 - [uPickle](https://github.com/lihaoyi/upickle-pprint)
 
@@ -28,7 +29,7 @@ libraryDependencies ++= Seq(
 
 ## Usage
 
-Mix `ArgonautSupport`, `FailFastCirceSupport` or `ErrorAccumulatingCirceSupport`, `JacksonSupport`, `Json4sSupport`, `JsoniterScalaSupport`, `PlayJsonSupport`, `UpickleSupport` or `AvroSupport` into your Akka HTTP code which is supposed to (un)marshal from/to JSON. Don't forget to provide the type class instances for the respective JSON libraries, if needed.
+Mix `ArgonautSupport`, `FailFastCirceSupport` or `ErrorAccumulatingCirceSupport`, `JacksonSupport`, `Json4sSupport`, `JsoniterScalaSupport`, `NinnySupport`, `PlayJsonSupport`, `UpickleSupport` or `AvroSupport` into your Akka HTTP code which is supposed to (un)marshal from/to JSON. Don't forget to provide the type class instances for the respective JSON libraries, if needed.
 
 ## Contribution policy ##
 

--- a/akka-http-ninny/src/main/scala/de/heikoseeberger/akkahttpninny/NinnySupport.scala
+++ b/akka-http-ninny/src/main/scala/de/heikoseeberger/akkahttpninny/NinnySupport.scala
@@ -1,0 +1,136 @@
+package de.heikoseeberger.akkahttpninny
+
+import java.nio.charset.StandardCharsets
+
+import akka.http.javadsl.common.JsonEntityStreamingSupport
+import akka.http.scaladsl.common.EntityStreamingSupport
+import akka.http.scaladsl.marshalling.{ Marshaller, Marshalling, ToEntityMarshaller }
+import akka.http.scaladsl.model.MediaTypes.`application/json`
+import akka.http.scaladsl.model.{ ContentTypeRange, HttpEntity, MediaType, MessageEntity }
+import akka.http.scaladsl.unmarshalling.{ FromEntityUnmarshaller, Unmarshal, Unmarshaller }
+import akka.http.scaladsl.util.FastFuture
+import akka.stream.scaladsl.{ Flow, Source }
+import akka.util.ByteString
+import io.github.kag0.ninny._
+
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
+import scala.util.control.NonFatal
+
+trait NinnySupport {
+  type SourceOf[A] = Source[A, _]
+
+  def unmarshallerContentTypes: Seq[ContentTypeRange] =
+    mediaTypes.map(ContentTypeRange.apply)
+
+  def mediaTypes: Seq[MediaType.WithFixedCharset] =
+    List(`application/json`)
+
+  /**
+    * HTTP entity => `A`
+    *
+    * @tparam A type to decode
+    * @return unmarshaller for `A`
+    */
+  implicit def unmarshaller[A: FromJson]: FromEntityUnmarshaller[A] =
+    Unmarshaller.byteStringUnmarshaller
+      .forContentTypes(unmarshallerContentTypes: _*)
+      .mapWithCharset {
+        case (ByteString.empty, _) => throw Unmarshaller.NoContentException
+        case (data, charset)       => data.decodeString(charset.nioCharset.name)
+      }
+      .map(Json.parse(_).to[A].get)
+
+  /**
+    * `A` => HTTP entity
+    *
+    * @tparam A type to encode
+    * @return marshaller for any `A` value
+    */
+  implicit def marshaller[A: ToSomeJson]: ToEntityMarshaller[A] =
+    Marshaller
+      .oneOf(mediaTypes: _*)(Marshaller.stringMarshaller)
+      .compose(Json.render)
+      .compose(_.toSomeJson)
+
+  /**
+    * `ByteString` => `A`
+    *
+    * @tparam A type to decode
+    * @return unmarshaller for any `A` value
+    */
+  implicit def fromByteStringUnmarshaller[A: FromJson]: Unmarshaller[ByteString, A] =
+    Unmarshaller(_ =>
+      bs => Future.fromTry(Json.parse(new String(bs.toArray, StandardCharsets.UTF_8)).to[A])
+    )
+
+  /**
+    * HTTP entity => `Source[A, _]`
+    *
+    * @tparam A type to decode
+    * @return unmarshaller for `Source[A, _]`
+    */
+  implicit def sourceUnmarshaller[A: FromJson](implicit
+      support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
+  ): FromEntityUnmarshaller[SourceOf[A]] =
+    Unmarshaller
+      .withMaterializer[HttpEntity, SourceOf[A]] { implicit ec => implicit mat => entity =>
+        def asyncParse(bs: ByteString) =
+          Unmarshal(bs).to[A]
+
+        def ordered =
+          Flow[ByteString].mapAsync(support.parallelism)(asyncParse)
+
+        def unordered =
+          Flow[ByteString].mapAsyncUnordered(support.parallelism)(asyncParse)
+
+        Future.successful {
+          entity.dataBytes
+            .via(support.framingDecoder)
+            .via(if (support.unordered) unordered else ordered)
+        }
+      }
+      .forContentTypes(unmarshallerContentTypes: _*)
+
+  /**
+    * `SourceOf[A]` => HTTP entity
+    *
+    * @tparam A type to encode
+    * @return marshaller for any `SourceOf[A]` value
+    */
+  implicit def sourceMarshaller[A](implicit
+      toJson: ToSomeJson[A],
+      support: JsonEntityStreamingSupport = EntityStreamingSupport.json()
+  ): ToEntityMarshaller[SourceOf[A]] =
+    jsonSourceStringMarshaller.compose(jsonSource[A])
+
+  private def sourceByteStringMarshaller(
+      mediaType: MediaType.WithFixedCharset
+  ): Marshaller[SourceOf[ByteString], MessageEntity] =
+    Marshaller[SourceOf[ByteString], MessageEntity] { implicit ec => value =>
+      try FastFuture.successful {
+        Marshalling.WithFixedContentType(
+          mediaType,
+          () => HttpEntity(contentType = mediaType, data = value)
+        ) :: Nil
+      } catch {
+        case NonFatal(e) => FastFuture.failed(e)
+      }
+    }
+
+  private lazy val jsonSourceStringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(sourceByteStringMarshaller)
+
+  private def jsonSource[A](entitySource: SourceOf[A])(implicit
+      toJson: ToSomeJson[A],
+      support: JsonEntityStreamingSupport
+  ): SourceOf[ByteString] =
+    entitySource
+      .map(_.toSomeJson)
+      .map(Json.render)
+      .map(ByteString(_))
+      .via(support.framingRenderer)
+
+}
+
+object NinnySupport extends NinnySupport

--- a/akka-http-ninny/src/test/scala/de/heikoseeberger/akkahttpninny/ExampleApp.scala
+++ b/akka-http-ninny/src/test/scala/de/heikoseeberger/akkahttpninny/ExampleApp.scala
@@ -1,0 +1,64 @@
+package de.heikoseeberger.akkahttpninny
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.{ HttpRequest, RequestEntity }
+import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.scaladsl.Source
+
+import scala.concurrent.duration._
+import scala.io.StdIn
+
+object ExampleApp {
+
+  private final case class Foo(bar: String)
+
+  def main(args: Array[String]): Unit = {
+    implicit val system = ActorSystem()
+
+    Http().newServerAt("127.0.0.1", 8000).bindFlow(route)
+
+    StdIn.readLine("Hit ENTER to exit")
+    system.terminate()
+  }
+
+  private def route(implicit sys: ActorSystem) = {
+    import Directives._
+    import NinnySupport._
+    import io.github.kag0.ninny.Auto._
+
+    pathSingleSlash {
+      post {
+        entity(as[Foo]) { foo =>
+          complete {
+            foo
+          }
+        }
+      }
+    } ~ pathPrefix("stream") {
+      post {
+        entity(as[SourceOf[Foo]]) { fooSource: SourceOf[Foo] =>
+          import sys._
+
+          Marshal(Source.single(Foo("a"))).to[RequestEntity]
+
+          complete(fooSource.throttle(1, 2.seconds))
+        }
+      } ~ get {
+        pathEndOrSingleSlash {
+          complete(
+            Source(0 to 5)
+              .throttle(1, 1.seconds)
+              .map(i => Foo(s"bar-$i"))
+          )
+        } ~ pathPrefix("remote") {
+          onSuccess(Http().singleRequest(HttpRequest(uri = "http://localhost:8000/stream"))) {
+            response => complete(Unmarshal(response).to[SourceOf[Foo]])
+          }
+        }
+      }
+    }
+  }
+}

--- a/akka-http-ninny/src/test/scala/de/heikoseeberger/akkahttpninny/NinnySupportSpec.scala
+++ b/akka-http-ninny/src/test/scala/de/heikoseeberger/akkahttpninny/NinnySupportSpec.scala
@@ -1,0 +1,108 @@
+package de.heikoseeberger.akkahttpninny
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.ContentTypes.{ `application/json`, `text/plain(UTF-8)` }
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
+import akka.http.scaladsl.unmarshalling.{ Unmarshal, Unmarshaller }
+import akka.stream.scaladsl.{ Sink, Source }
+import io.github.kag0.ninny.JsonException
+import org.scalatest.BeforeAndAfterAll
+
+import scala.collection.immutable.Seq
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+
+object NinnySupportSpec {
+
+  final case class Foo(bar: String) {
+    require(bar startsWith "bar", "bar must start with 'bar'!")
+  }
+}
+
+final class NinnySupportSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll {
+  import NinnySupport._
+  import NinnySupportSpec._
+  import io.github.kag0.ninny.Auto._
+
+  private implicit val system = ActorSystem()
+
+  "NinnySupport" should {
+    "enable marshalling and unmarshalling objects for which `ToJson` and `FromSomeJson` exist" in {
+      val foo = Foo("bar")
+      Marshal(foo)
+        .to[RequestEntity]
+        .flatMap(Unmarshal(_).to[Foo])
+        .map(_ shouldBe foo)
+    }
+
+    "enable streamed marshalling and unmarshalling for json arrays" in {
+      val foos = (0 to 100).map(i => Foo(s"bar-$i")).toList
+
+      Marshal(Source(foos))
+        .to[RequestEntity]
+        .flatMap(entity => Unmarshal(entity).to[SourceOf[Foo]])
+        .flatMap(_.runWith(Sink.seq))
+        .map(_ shouldBe foos)
+    }
+
+    "provide proper error messages for requirement errors" in {
+      val entity = HttpEntity(MediaTypes.`application/json`, """{ "bar": "baz" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ should have message "requirement failed: bar must start with 'bar'!")
+    }
+
+    "provide stringified error representation for parsing errors" in {
+      val entity = HttpEntity(MediaTypes.`application/json`, """{ "bar": 5 }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map { err =>
+          err shouldBe a[JsonException]
+          err should have message "Expected string, got 5"
+        }
+    }
+
+    "fail with NoContentException when unmarshalling empty entities" in {
+      val entity = HttpEntity.empty(`application/json`)
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(_ shouldBe Unmarshaller.NoContentException)
+    }
+
+    "fail with UnsupportedContentTypeException when Content-Type is not `application/json`" in {
+      val entity = HttpEntity("""{ "bar": "bar" }""")
+      Unmarshal(entity)
+        .to[Foo]
+        .failed
+        .map(
+          _ shouldBe UnsupportedContentTypeException(Some(`text/plain(UTF-8)`), `application/json`)
+        )
+    }
+
+    "allow unmarshalling with passed in Content-Types" in {
+      val foo = Foo("bar")
+      val `application/json-home` =
+        MediaType.applicationWithFixedCharset("json-home", HttpCharsets.`UTF-8`, "json-home")
+
+      final object CustomNinnySupport extends NinnySupport {
+        override def unmarshallerContentTypes = List(`application/json`, `application/json-home`)
+      }
+      import CustomNinnySupport._
+
+      val entity = HttpEntity(`application/json-home`, """{ "bar": "bar" }""")
+      Unmarshal(entity).to[Foo].map(_ shouldBe foo)
+    }
+  }
+
+  override protected def afterAll() = {
+    Await.ready(system.terminate(), 42.seconds)
+    super.afterAll()
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -4,15 +4,19 @@ inThisBuild(
     homepage := Some(url("https://github.com/hseeberger/akka-http-json")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     scmInfo := Some(
-      ScmInfo(url("https://github.com/hseeberger/akka-http-json"),
-              "git@github.com:hseeberger/akka-http-json.git")
+      ScmInfo(
+        url("https://github.com/hseeberger/akka-http-json"),
+        "git@github.com:hseeberger/akka-http-json.git"
+      )
     ),
     developers := List(
-      Developer("hseeberger",
-                "Heiko Seeberger",
-                "mail@heikoseeberger.de",
-                url("https://github.com/hseeberger"))
-    ),
+      Developer(
+        "hseeberger",
+        "Heiko Seeberger",
+        "mail@heikoseeberger.de",
+        url("https://github.com/hseeberger")
+      )
+    )
   )
 )
 
@@ -81,7 +85,7 @@ lazy val `akka-http-jackson` =
         library.akkaStream % Provided,
         library.akkaHttpJacksonJava,
         library.jacksonModuleScala,
-        "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+        "org.scala-lang"  % "scala-reflect" % scalaVersion.value,
         library.scalaTest % Test
       )
     )
@@ -163,7 +167,7 @@ lazy val `akka-http-avro4s` =
         library.akkaHttp,
         library.akkaStream % Provided,
         library.avro4sJson,
-        library.scalaTest     % Test
+        library.scalaTest % Test
       )
     )
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,17 +32,18 @@ lazy val `akka-http-json` =
       `akka-http-jackson`,
       `akka-http-json4s`,
       `akka-http-jsoniter-scala`,
+      `akka-http-ninny`,
       `akka-http-play-json`,
-      `akka-http-upickle`,
+      `akka-http-upickle`
     )
     .settings(settings)
     .settings(
       Compile / unmanagedSourceDirectories := Seq.empty,
-      Test / unmanagedSourceDirectories    := Seq.empty,
+      Test / unmanagedSourceDirectories := Seq.empty,
       publishArtifact := false
     )
 
-lazy val `akka-http-argonaut`=
+lazy val `akka-http-argonaut` =
   project
     .enablePlugins(AutomateHeaderPlugin)
     .settings(settings)
@@ -110,6 +111,19 @@ lazy val `akka-http-jsoniter-scala` =
         library.akkaStream % Provided,
         library.jsoniterScalaCore,
         library.jsoniterScalaMacros % Test,
+        library.scalaTest           % Test
+      )
+    )
+
+lazy val `akka-http-ninny` =
+  project
+    .enablePlugins(AutomateHeaderPlugin)
+    .settings(settings)
+    .settings(
+      libraryDependencies ++= Seq(
+        library.akkaHttp,
+        library.akkaStream % Provided,
+        library.ninny,
         library.scalaTest % Test
       )
     )
@@ -181,29 +195,34 @@ lazy val library =
       val jacksonModuleScala = "2.11.2"
       val jsoniterScala      = "2.6.0"
       val json4s             = "3.6.9"
+      val ninny              = "0.1.3"
       val play               = "2.9.1"
       val scalaTest          = "3.2.2"
       val upickle            = "1.2.0"
       val avsystemCommons    = "1.40.0"
     }
-    val akkaHttp            = "com.typesafe.akka"                     %% "akka-http"             % Version.akkaHttp
-    val akkaHttpJacksonJava = "com.typesafe.akka"                     %% "akka-http-jackson"     % Version.akkaHttp
-    val akkaStream          = "com.typesafe.akka"                     %% "akka-stream"           % Version.akka
-    val argonaut            = "io.argonaut"                           %% "argonaut"              % Version.argonaut
-    val avro4sJson          = "com.sksamuel.avro4s"                   %% "avro4s-json"           % Version.avro4s
-    val avsystemCommons     = "com.avsystem.commons"                  %% "commons-core"          % Version.avsystemCommons
-    val circe               = "io.circe"                              %% "circe-core"            % Version.circe
-    val circeParser         = "io.circe"                              %% "circe-parser"          % Version.circe
-    val circeGeneric        = "io.circe"                              %% "circe-generic"         % Version.circe
-    val jacksonModuleScala  = "com.fasterxml.jackson.module"          %% "jackson-module-scala"  % Version.jacksonModuleScala
-    val json4sCore          = "org.json4s"                            %% "json4s-core"           % Version.json4s
-    val json4sJackson       = "org.json4s"                            %% "json4s-jackson"        % Version.json4s
-    val json4sNative        = "org.json4s"                            %% "json4s-native"         % Version.json4s
-    val jsoniterScalaCore   = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % Version.jsoniterScala
-    val jsoniterScalaMacros = "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % Version.jsoniterScala
-    val playJson            = "com.typesafe.play"                     %% "play-json"             % Version.play
-    val scalaTest           = "org.scalatest"                         %% "scalatest"             % Version.scalaTest
-    val upickle             = "com.lihaoyi"                           %% "upickle"               % Version.upickle
+    val akkaHttp            = "com.typesafe.akka"    %% "akka-http"         % Version.akkaHttp
+    val akkaHttpJacksonJava = "com.typesafe.akka"    %% "akka-http-jackson" % Version.akkaHttp
+    val akkaStream          = "com.typesafe.akka"    %% "akka-stream"       % Version.akka
+    val argonaut            = "io.argonaut"          %% "argonaut"          % Version.argonaut
+    val avro4sJson          = "com.sksamuel.avro4s"  %% "avro4s-json"       % Version.avro4s
+    val avsystemCommons     = "com.avsystem.commons" %% "commons-core"      % Version.avsystemCommons
+    val circe               = "io.circe"             %% "circe-core"        % Version.circe
+    val circeParser         = "io.circe"             %% "circe-parser"      % Version.circe
+    val circeGeneric        = "io.circe"             %% "circe-generic"     % Version.circe
+    val jacksonModuleScala =
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % Version.jacksonModuleScala
+    val json4sCore    = "org.json4s" %% "json4s-core"    % Version.json4s
+    val json4sJackson = "org.json4s" %% "json4s-jackson" % Version.json4s
+    val json4sNative  = "org.json4s" %% "json4s-native"  % Version.json4s
+    val jsoniterScalaCore =
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % Version.jsoniterScala
+    val jsoniterScalaMacros =
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % Version.jsoniterScala
+    val ninny     = "io.github.kag0"    %% "ninny"     % Version.ninny
+    val playJson  = "com.typesafe.play" %% "play-json" % Version.play
+    val scalaTest = "org.scalatest"     %% "scalatest" % Version.scalaTest
+    val upickle   = "com.lihaoyi"       %% "upickle"   % Version.upickle
   }
 
 // *****************************************************************************
@@ -227,12 +246,15 @@ lazy val commonSettings =
       "-deprecation",
       "-language:_",
       "-target:jvm-1.8",
-      "-encoding", "UTF-8"
+      "-encoding",
+      "UTF-8"
     ),
     Compile / unmanagedSourceDirectories := Seq((Compile / scalaSource).value),
     Test / unmanagedSourceDirectories := Seq((Test / scalaSource).value),
-    mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% name.value % _).toSet,
-)
+    mimaPreviousArtifacts := previousStableVersion.value
+      .map(organization.value %% name.value % _)
+      .toSet
+  )
 
 lazy val gitSettings =
   Seq(
@@ -246,5 +268,5 @@ lazy val scalafmtSettings =
 
 lazy val publishSettings =
   Seq(
-    pomIncludeRepository := (_ => false),
+    pomIncludeRepository := (_ => false)
   )


### PR DESCRIPTION
I added support for https://github.com/kag0/ninny-json, if you'll have it.

Some things shamelessly copied from the other implementations.

Sorry for the whitespace changes, my editor picked up the scalafmt config and reformatted all the files I touched. I can get rid of them if you want.