### PR TITLE
JacksonSupport trait should not fix ObjectMapper to concrete instance

### DIFF
--- a/akka-http-jackson/src/main/scala/de/heikoseeberger/akkahttpjackson/JacksonSupport.scala
+++ b/akka-http-jackson/src/main/scala/de/heikoseeberger/akkahttpjackson/JacksonSupport.scala
@@ -53,7 +53,7 @@ object JacksonSupport extends JacksonSupport {
 trait JacksonSupport {
   type SourceOf[A] = Source[A, _]
 
-  import JacksonSupport._
+  def defaultObjectMapper: ObjectMapper
 
   def unmarshallerContentTypes: Seq[ContentTypeRange] =
     mediaTypes.map(ContentTypeRange.apply)


### PR DESCRIPTION
Classes mixing in the trait should be free to provide a own instance of ObjectMapper. Those who simply import the companion object are fine with the default one.