### PR TITLE
Update zio-json to 0.3.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -235,7 +235,7 @@ lazy val library =
       val play               = "2.9.2"
       val scalaTest          = "3.2.11"
       val upickle            = "1.5.0"
-      val zioJson            = "0.1.5"
+      val zioJson            = "0.3.0-RC2"
     }
     // format: off
     val akkaHttp            = "com.typesafe.akka"                     %% "akka-http"             % Version.akkaHttp


### PR DESCRIPTION
Hello,

We are using your library in one of our project. The zio/zio-stream has been at release candidate state for already a long time and there is a change in the interface of `ZStream`. 
I updated the version and ran the test.

Would you be willing to publish a release candidate version of your library based on the change of zio/zio-stream?

Thanks