### PR TITLE
upgraded to zio-json 0.3.0-RC9

### DIFF
--- a/akka-http-zio-json/src/test/scala/de/heikoseeberger/akkahttpziojson/ExampleApp.scala
+++ b/akka-http-zio-json/src/test/scala/de/heikoseeberger/akkahttpziojson/ExampleApp.scala
@@ -34,6 +34,8 @@ object ExampleApp {
     implicit val fooDecoder: JsonDecoder[Foo] = DeriveJsonDecoder.gen
   }
 
+  private implicit val rt: zio.Runtime[Any] = zio.Runtime.default
+
   def main(args: Array[String]): Unit = {
     implicit val system = ActorSystem()
 

--- a/akka-http-zio-json/src/test/scala/de/heikoseeberger/akkahttpziojson/ZioJsonSupportSpec.scala
+++ b/akka-http-zio-json/src/test/scala/de/heikoseeberger/akkahttpziojson/ZioJsonSupportSpec.scala
@@ -48,6 +48,8 @@ object ZioJsonSupportSpec {
   implicit val fooDecoder: JsonDecoder[Foo]             = DeriveJsonDecoder.gen
   implicit val multiFooDecoder: JsonDecoder[MultiFoo]   = DeriveJsonDecoder.gen
   implicit val optionFooDecoder: JsonDecoder[OptionFoo] = DeriveJsonDecoder.gen
+
+  implicit val rt: zio.Runtime[Any] = zio.Runtime.default
 }
 
 final class ZioJsonSupportSpec

--- a/build.sbt
+++ b/build.sbt
@@ -235,7 +235,7 @@ lazy val library =
       val play               = "2.9.2"
       val scalaTest          = "3.2.11"
       val upickle            = "1.5.0"
-      val zioJson            = "0.3.0-RC6"
+      val zioJson            = "0.3.0-RC9"
     }
     // format: off
     val akkaHttp            = "com.typesafe.akka"                     %% "akka-http"             % Version.akkaHttp


### PR DESCRIPTION
* upgrades to zio-json 0.3.0-RC9
* expects zio.Runtime to be provided implicitly 

@hseeberger if this looks good can a new RC be cut?